### PR TITLE
Tweak build system tracking Fontship changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ nofea=$(strip $(foreach f,Initials Keyboard Mono,$(findstring $f,$1)))
 
 define otf_instance_template =
 
-$$(BUILDDIR)/$1-%-instance.otf: sources/$1-%.sfd $(GSUB) $(BUILD) | $$(BUILDDIR)
+$$(BUILDDIR)/$1-%-instance.otf: $$(BUILDDIR)/$1-%-normalized.sfd $(GSUB) $(BUILD)
 	$$(PYTHON) $(BUILD) \
 		--input=$$< \
 		--output=$$@ \

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,6 @@
-PROJECT = Libertinus
-
-STATICOTF = true
 STATICTTF =
 STATICWOFF =
 STATICWOFF2 =
-VARIABLETTF =
-VARIABLEOTF =
-VARIABLEWOFF =
-VARIABLEWOFF2 =
 
 GSUB = sources/features/gsub.fea
 DOCSDIR = documentation
@@ -19,14 +12,10 @@ SERIF_STYLES := Regular Semibold Bold Italic SemiboldItalic BoldItalic
 SANS_STYLES  := Regular Bold Italic
 REGULAR_ONLY := Math Mono Keyboard SerifDisplay SerifInitials
 
-sfdFamilyNames = $(shell sed -n '/FamilyName/{s/.*: //;s/ //g;p}' $1)
-
 FontStyles = $(SERIF_STYLES)
 INSTANCES = $(foreach STYLE,$(SERIF_STYLES),$(PROJECT)Serif-$(STYLE)) \
 			$(foreach STYLE,$(SANS_STYLES),$(PROJECT)Sans-$(STYLE)) \
 			$(foreach FACE,$(REGULAR_ONLY),$(PROJECT)$(FACE)-Regular)
-
-default: all
 
 nofea=$(strip $(foreach f,Initials Keyboard Mono,$(findstring $f,$1)))
 

--- a/sources/LibertinusKeyboard-Regular.sfd
+++ b/sources/LibertinusKeyboard-Regular.sfd
@@ -42,7 +42,7 @@ HheadDOffset: 0
 OS2CapHeight: 754
 OS2XHeight: 754
 OS2FamilyClass: 2063
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 4 0 1 "'liga' Standardligaturen" { "'liga' Standardligaturen 1"  } ['liga' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 MarkAttachClasses: 1
 DEI: 91125

--- a/sources/LibertinusMath-Regular.sfd
+++ b/sources/LibertinusMath-Regular.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 658
 OS2XHeight: 429
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]
 Lookup: 260 0 0 "'mark' Mark positioning" { "'mark' Right"  "'mark' Komb OR"  "'mark' Above"  "'mark' Middle"  "'mark' Ogonek"  "'mark' Cedilla"  "'mark' Below"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]

--- a/sources/LibertinusMono-Regular.sfd
+++ b/sources/LibertinusMono-Regular.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 613
 OS2XHeight: 495
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 6 0 0 "'ccmp' Contextual Chaining Substitution" { "'ccmp' Contextual Chaining Substitution 1"  } ['ccmp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 1 0 0 "'locl' Localised Forms for Sami" { "'locl' Localised Forms for Sami-1"  } ['locl' ('latn' <'FIN ' 'ISM ' 'LSM ' 'NOR ' 'NSM ' 'SKS ' 'SSM ' 'SVE ' > ) ]
 Lookup: 1 0 0 "Substitution dotless forms" { "Substitution dotless forms 1"  } []

--- a/sources/LibertinusSans-Bold.sfd
+++ b/sources/LibertinusSans-Bold.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 645
 OS2XHeight: 429
 OS2FamilyClass: 2050
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]

--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 658
 OS2XHeight: 429
 OS2FamilyClass: 2050
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]

--- a/sources/LibertinusSans-Regular.sfd
+++ b/sources/LibertinusSans-Regular.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 658
 OS2XHeight: 460
 OS2FamilyClass: 2050
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]

--- a/sources/LibertinusSerif-Bold.sfd
+++ b/sources/LibertinusSerif-Bold.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 645
 OS2XHeight: 433
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 645
 OS2XHeight: 429
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]
 Lookup: 257 0 0 "'cpsp' Versalabstaende" { "'cpsp' Versalabstaende 1"  } ['cpsp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 645
 OS2XHeight: 429
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 658
 OS2XHeight: 429
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Smallcap kerning" { "'kern' Small Caps" [150,15,4] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]

--- a/sources/LibertinusSerif-Semibold.sfd
+++ b/sources/LibertinusSerif-Semibold.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 645
 OS2XHeight: 463
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 257 0 0 "'cpsp' Versalabstaende" { "'cpsp' Versalabstaende 1"  } ['cpsp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 260 0 0 "'mark' Mark positioning" { "'mark' Mark Positioning in Hebrew lookup 0"  "'mark' Mark Positioning lookup 1"  "'mark' Mark Positioning lookup 2"  "'mark' Mark Positioning lookup 3"  "'mark' Mark Positioning lookup 4"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Kerning" { "'kern' Kerning 1" [150,0,0] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]

--- a/sources/LibertinusSerif-SemiboldItalic.sfd
+++ b/sources/LibertinusSerif-SemiboldItalic.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 645
 OS2XHeight: 445
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 258 0 0 "'kern' Horizontales Kerning in Cyrillic lookup 0" { "'kern' Horizontales Kerning in Cyrillic lookup 0"  } ['kern' ('cyrl' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Horizontales Kerning in Latin lookup 1" { "'kern' Horizontales Kerning in Latin lookup 1" [150,15,0] } ['kern' ('latn' <'dflt' > ) ]
 Lookup: 260 0 0 "'mark' Mark positioning" { "'mark' Right"  "'mark' Top Punkt"  "'mark' Komb OR"  "'mark' Above"  "'mark' Middle"  "'mark' Ogonek"  "'mark' Cedilla"  "'mark' Below"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]

--- a/sources/LibertinusSerifDisplay-Regular.sfd
+++ b/sources/LibertinusSerifDisplay-Regular.sfd
@@ -41,7 +41,7 @@ HheadDOffset: 0
 OS2CapHeight: 658
 OS2XHeight: 409
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 257 0 0 "'cpsp' Versalabstaende" { "'cpsp' Versalabstaende 1"  } ['cpsp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 260 0 0 "'mark' Mark positioning" { "'mark' Right"  "'mark' Komb OR"  "'mark' Above"  "'mark' Middle"  "'mark' Ogonek"  "'mark' Cedilla"  "'mark' Below"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 262 0 0 "'mkmk' Mark to Mark" { "'mkmk' Mark to Mark-1"  } ['mkmk' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]

--- a/sources/LibertinusSerifInitials-Regular.sfd
+++ b/sources/LibertinusSerifInitials-Regular.sfd
@@ -40,7 +40,7 @@ HheadDescent: -246
 HheadDOffset: 0
 OS2CapHeight: 688
 OS2FamilyClass: 261
-OS2Vendor: 'QUE'
+OS2Vendor: 'QUE '
 Lookup: 257 0 0 "'cpsp' Capital Spacing lookup 0" { "'cpsp' Capital Spacing lookup 0 subtable"  } ['cpsp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 260 0 0 "'mark' Mark Positioning lookup 1" { "'mark' Mark Positioning lookup 1 subtable"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Horizontal Kerning lookup 2" { "'kern' Kerning 1" [150,0,0] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]


### PR DESCRIPTION
Also FontForge and fonttools don't agree on how to encode OS2Vendor strings when they need padding, but this way seems to get them in as few fights as possible. Also thanks to this I had change how I was thinking about normalization in Fontship, but that is probably for the best in the long run.