### PR TITLE
Normalize FontForge sources

### DIFF
--- a/sources/LibertinusKeyboard-Regular.sfd
+++ b/sources/LibertinusKeyboard-Regular.sfd
@@ -48,7 +48,7 @@ MarkAttachClasses: 1
 DEI: 91125
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
 GaspTable: 3 8 2 17 1 65535 3 0
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 9
@@ -111,7 +111,7 @@ Grid
  432 575 l 1049
 432 580 m 1049
 EndSplineSet
-BeginChars: 65608 419
+BeginChars: 1114184 419
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -11275,7 +11275,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: .notdef
-Encoding: 65536 -1 295
+Encoding: 1114112 -1 295
 Width: 500
 Flags: MW
 LayerCount: 3
@@ -12507,7 +12507,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: uniE104
-Encoding: 65537 -1 335
+Encoding: 1114113 -1 335
 Width: 1470
 Flags: MW
 LayerCount: 3
@@ -12670,7 +12670,7 @@ Refer: 415 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE130
-Encoding: 65538 -1 339
+Encoding: 1114114 -1 339
 Width: 1008
 Flags: MW
 LayerCount: 3
@@ -12714,7 +12714,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: S_t_r_g
-Encoding: 65539 -1 340
+Encoding: 1114115 -1 340
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -12849,7 +12849,7 @@ Ligature2: "'liga' Standardligaturen 1" S t r g
 EndChar
 
 StartChar: A_l_t
-Encoding: 65540 -1 341
+Encoding: 1114116 -1 341
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -12935,7 +12935,7 @@ Ligature2: "'liga' Standardligaturen 1" A l t
 EndChar
 
 StartChar: A_l_t_G_r
-Encoding: 65541 -1 342
+Encoding: 1114117 -1 342
 Width: 2425
 GlyphClass: 3
 Flags: MW
@@ -13064,7 +13064,7 @@ Ligature2: "'liga' Standardligaturen 1" A l t G r
 EndChar
 
 StartChar: F_one
-Encoding: 65542 -1 343
+Encoding: 1114118 -1 343
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13136,7 +13136,7 @@ Ligature2: "'liga' Standardligaturen 1" F one
 EndChar
 
 StartChar: F_two
-Encoding: 65543 -1 344
+Encoding: 1114119 -1 344
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13214,7 +13214,7 @@ Ligature2: "'liga' Standardligaturen 1" F two
 EndChar
 
 StartChar: F_three
-Encoding: 65544 -1 345
+Encoding: 1114120 -1 345
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13293,7 +13293,7 @@ Ligature2: "'liga' Standardligaturen 1" F three
 EndChar
 
 StartChar: F_four
-Encoding: 65545 -1 346
+Encoding: 1114121 -1 346
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13375,7 +13375,7 @@ Ligature2: "'liga' Standardligaturen 1" F four
 EndChar
 
 StartChar: F_five
-Encoding: 65546 -1 347
+Encoding: 1114122 -1 347
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13453,7 +13453,7 @@ Ligature2: "'liga' Standardligaturen 1" F five
 EndChar
 
 StartChar: F_six
-Encoding: 65547 -1 348
+Encoding: 1114123 -1 348
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13525,7 +13525,7 @@ Ligature2: "'liga' Standardligaturen 1" F six
 EndChar
 
 StartChar: F_seven
-Encoding: 65548 -1 349
+Encoding: 1114124 -1 349
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13593,7 +13593,7 @@ Ligature2: "'liga' Standardligaturen 1" F seven
 EndChar
 
 StartChar: F_eight
-Encoding: 65549 -1 350
+Encoding: 1114125 -1 350
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13674,7 +13674,7 @@ Ligature2: "'liga' Standardligaturen 1" F eight
 EndChar
 
 StartChar: F_nine
-Encoding: 65550 -1 351
+Encoding: 1114126 -1 351
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -13746,7 +13746,7 @@ Ligature2: "'liga' Standardligaturen 1" F nine
 EndChar
 
 StartChar: F_one_zero
-Encoding: 65551 -1 352
+Encoding: 1114127 -1 352
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -13829,7 +13829,7 @@ Ligature2: "'liga' Standardligaturen 1" F one zero
 EndChar
 
 StartChar: F_one_one
-Encoding: 65552 -1 353
+Encoding: 1114128 -1 353
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -13917,7 +13917,7 @@ Ligature2: "'liga' Standardligaturen 1" F one one
 EndChar
 
 StartChar: F_one_two
-Encoding: 65553 -1 354
+Encoding: 1114129 -1 354
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -14011,7 +14011,7 @@ Ligature2: "'liga' Standardligaturen 1" F one two
 EndChar
 
 StartChar: F_one_three
-Encoding: 65554 -1 355
+Encoding: 1114130 -1 355
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -14106,7 +14106,7 @@ Ligature2: "'liga' Standardligaturen 1" F one three
 EndChar
 
 StartChar: F_one_four
-Encoding: 65555 -1 356
+Encoding: 1114131 -1 356
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -14204,7 +14204,7 @@ Ligature2: "'liga' Standardligaturen 1" F one four
 EndChar
 
 StartChar: F_one_five
-Encoding: 65556 -1 357
+Encoding: 1114132 -1 357
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -14298,7 +14298,7 @@ Ligature2: "'liga' Standardligaturen 1" F one five
 EndChar
 
 StartChar: F_one_six
-Encoding: 65557 -1 358
+Encoding: 1114133 -1 358
 Width: 1600
 GlyphClass: 3
 Flags: MW
@@ -14386,7 +14386,7 @@ Ligature2: "'liga' Standardligaturen 1" F one six
 EndChar
 
 StartChar: C_t_r_l
-Encoding: 65558 -1 359
+Encoding: 1114134 -1 359
 Width: 2400
 GlyphClass: 3
 Flags: MW
@@ -14489,7 +14489,7 @@ Ligature2: "'liga' Standardligaturen 1" C t r l
 EndChar
 
 StartChar: S_h_i_f_t
-Encoding: 65559 -1 360
+Encoding: 1114135 -1 360
 Width: 1470
 GlyphClass: 3
 Flags: MW
@@ -14536,7 +14536,7 @@ Ligature2: "'liga' Standardligaturen 1" S h i f t
 EndChar
 
 StartChar: T_a_b
-Encoding: 65560 -1 361
+Encoding: 1114136 -1 361
 Width: 1470
 GlyphClass: 3
 Flags: MW
@@ -14593,7 +14593,7 @@ Ligature2: "'liga' Standardligaturen 1" T a b
 EndChar
 
 StartChar: E_n_t_e_r
-Encoding: 65561 -1 362
+Encoding: 1114137 -1 362
 Width: 1470
 GlyphClass: 3
 Flags: MW
@@ -14642,7 +14642,7 @@ Ligature2: "'liga' Standardligaturen 1" E n t e r
 EndChar
 
 StartChar: G_N_U
-Encoding: 65562 -1 363
+Encoding: 1114138 -1 363
 Width: 1470
 GlyphClass: 3
 Flags: MW
@@ -15301,7 +15301,7 @@ Ligature2: "'liga' Standardligaturen 1" G N U
 EndChar
 
 StartChar: P_o_s_one
-Encoding: 65563 -1 364
+Encoding: 1114139 -1 364
 Width: 1970
 GlyphClass: 3
 Flags: MW
@@ -15397,7 +15397,7 @@ Ligature2: "'liga' Standardligaturen 1" P o s one
 EndChar
 
 StartChar: E_n_t_f
-Encoding: 65564 -1 365
+Encoding: 1114140 -1 365
 Width: 1970
 GlyphClass: 3
 Flags: MW
@@ -15540,7 +15540,7 @@ Ligature2: "'liga' Standardligaturen 1" E n t f
 EndChar
 
 StartChar: E_i_n_f
-Encoding: 65565 -1 366
+Encoding: 1114141 -1 366
 Width: 1970
 GlyphClass: 3
 Flags: MW
@@ -15678,7 +15678,7 @@ Ligature2: "'liga' Standardligaturen 1" E i n f
 EndChar
 
 StartChar: L_e_e_r
-Encoding: 65566 -1 367
+Encoding: 1114142 -1 367
 Width: 3080
 GlyphClass: 3
 Flags: MW
@@ -15812,7 +15812,7 @@ Ligature2: "'liga' Standardligaturen 1" L e e r
 EndChar
 
 StartChar: E_s_c
-Encoding: 65567 -1 368
+Encoding: 1114143 -1 368
 Width: 1650
 GlyphClass: 3
 Flags: MW
@@ -15907,7 +15907,7 @@ Ligature2: "'liga' Standardligaturen 1" E s c
 EndChar
 
 StartChar: E_n_d_e
-Encoding: 65568 -1 369
+Encoding: 1114144 -1 369
 Width: 2110
 GlyphClass: 3
 Flags: MW
@@ -16036,7 +16036,7 @@ Ligature2: "'liga' Standardligaturen 1" E n d e
 EndChar
 
 StartChar: C_a_p_s_l_o_c_k
-Encoding: 65569 -1 370
+Encoding: 1114145 -1 370
 Width: 1820
 GlyphClass: 3
 Flags: MW
@@ -16083,7 +16083,7 @@ Ligature2: "'liga' Standardligaturen 1" C a p s l o c k
 EndChar
 
 StartChar: B_a_c_k
-Encoding: 65570 -1 371
+Encoding: 1114146 -1 371
 Width: 1920
 GlyphClass: 3
 Flags: MW
@@ -16234,7 +16234,7 @@ EndSplineSet
 EndChar
 
 StartChar: H_o_m_e
-Encoding: 65571 -1 374
+Encoding: 1114147 -1 374
 Width: 2460
 GlyphClass: 3
 Flags: MW
@@ -16362,7 +16362,7 @@ Ligature2: "'liga' Standardligaturen 1" H o m e
 EndChar
 
 StartChar: D_e_l
-Encoding: 65572 -1 375
+Encoding: 1114148 -1 375
 Width: 1730
 GlyphClass: 3
 Flags: MW
@@ -16439,7 +16439,7 @@ Ligature2: "'liga' Standardligaturen 1" D e l
 EndChar
 
 StartChar: I_n_s
-Encoding: 65573 -1 376
+Encoding: 1114149 -1 376
 Width: 1490
 GlyphClass: 3
 Flags: MW
@@ -16529,7 +16529,7 @@ Ligature2: "'liga' Standardligaturen 1" I n s
 EndChar
 
 StartChar: E_n_d
-Encoding: 65574 -1 377
+Encoding: 1114150 -1 377
 Width: 1800
 GlyphClass: 3
 Flags: MW
@@ -16920,7 +16920,7 @@ EndSplineSet
 EndChar
 
 StartChar: S_p_a_c_e
-Encoding: 65575 -1 383
+Encoding: 1114151 -1 383
 Width: 3840
 GlyphClass: 3
 Flags: MW
@@ -16950,7 +16950,7 @@ Ligature2: "'liga' Standardligaturen 1" S p a c e
 EndChar
 
 StartChar: P_a_d_zero
-Encoding: 65576 -1 384
+Encoding: 1114152 -1 384
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17065,7 +17065,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d zero
 EndChar
 
 StartChar: P_a_d_one
-Encoding: 65577 -1 385
+Encoding: 1114153 -1 385
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17185,7 +17185,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d one
 EndChar
 
 StartChar: P_a_d_two
-Encoding: 65578 -1 386
+Encoding: 1114154 -1 386
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17311,7 +17311,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d two
 EndChar
 
 StartChar: P_a_d_three
-Encoding: 65579 -1 387
+Encoding: 1114155 -1 387
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17438,7 +17438,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d three
 EndChar
 
 StartChar: P_a_d_four
-Encoding: 65580 -1 388
+Encoding: 1114156 -1 388
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17568,7 +17568,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d four
 EndChar
 
 StartChar: P_a_d_five
-Encoding: 65581 -1 389
+Encoding: 1114157 -1 389
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17694,7 +17694,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d five
 EndChar
 
 StartChar: P_a_d_six
-Encoding: 65582 -1 390
+Encoding: 1114158 -1 390
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17814,7 +17814,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d six
 EndChar
 
 StartChar: P_a_d_seven
-Encoding: 65583 -1 391
+Encoding: 1114159 -1 391
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -17930,7 +17930,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d seven
 EndChar
 
 StartChar: P_a_d_eight
-Encoding: 65584 -1 392
+Encoding: 1114160 -1 392
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -18059,7 +18059,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d eight
 EndChar
 
 StartChar: P_a_d_nine
-Encoding: 65585 -1 393
+Encoding: 1114161 -1 393
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -18179,7 +18179,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d nine
 EndChar
 
 StartChar: P_a_d_divide
-Encoding: 65586 -1 394
+Encoding: 1114162 -1 394
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -18309,7 +18309,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d divide
 EndChar
 
 StartChar: P_a_d_plus
-Encoding: 65587 -1 395
+Encoding: 1114163 -1 395
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -18427,7 +18427,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d plus
 EndChar
 
 StartChar: P_a_d_hyphen
-Encoding: 65588 -1 396
+Encoding: 1114164 -1 396
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -18539,7 +18539,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d hyphen
 EndChar
 
 StartChar: P_a_d_multiply
-Encoding: 65589 -1 397
+Encoding: 1114165 -1 397
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -18657,7 +18657,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d multiply
 EndChar
 
 StartChar: F_n
-Encoding: 65590 -1 398
+Encoding: 1114166 -1 398
 Width: 1340
 GlyphClass: 3
 Flags: MW
@@ -18741,7 +18741,7 @@ Ligature2: "'liga' Standardligaturen 1" F n
 EndChar
 
 StartChar: uniE131
-Encoding: 65591 -1 399
+Encoding: 1114167 -1 399
 Width: 1008
 Flags: MW
 LayerCount: 3
@@ -18786,7 +18786,7 @@ Refer: 339 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE132
-Encoding: 65592 -1 400
+Encoding: 1114168 -1 400
 Width: 1008
 Flags: MW
 LayerCount: 3
@@ -18825,7 +18825,7 @@ Refer: 339 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE133
-Encoding: 65593 -1 401
+Encoding: 1114169 -1 401
 Width: 1008
 Flags: MW
 LayerCount: 3
@@ -18865,7 +18865,7 @@ Refer: 339 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE134
-Encoding: 65594 -1 402
+Encoding: 1114170 -1 402
 Width: 1008
 Flags: MW
 LayerCount: 3
@@ -18904,7 +18904,7 @@ Refer: 339 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE135
-Encoding: 65595 -1 403
+Encoding: 1114171 -1 403
 Width: 1008
 Flags: MW
 LayerCount: 3
@@ -18937,7 +18937,7 @@ Refer: 339 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: P_a_d_e_n_t_e_r
-Encoding: 65596 -1 404
+Encoding: 1114172 -1 404
 Width: 1950
 GlyphClass: 3
 Flags: MW
@@ -19052,7 +19052,7 @@ Ligature2: "'liga' Standardligaturen 1" P a d e n t e r
 EndChar
 
 StartChar: B_i_l_d_u_p
-Encoding: 65597 -1 405
+Encoding: 1114173 -1 405
 Width: 2170
 GlyphClass: 3
 Flags: MW
@@ -19174,7 +19174,7 @@ Ligature2: "'liga' Standardligaturen 1" B i l d u p
 EndChar
 
 StartChar: B_i_l_d_d_o_w_n
-Encoding: 65598 -1 406
+Encoding: 1114174 -1 406
 Width: 2170
 GlyphClass: 3
 Flags: MW
@@ -19296,7 +19296,7 @@ Ligature2: "'liga' Standardligaturen 1" B i l d d o w n
 EndChar
 
 StartChar: P_a_g_e_u_p
-Encoding: 65599 -1 407
+Encoding: 1114175 -1 407
 Width: 2380
 GlyphClass: 3
 Flags: MW
@@ -19438,7 +19438,7 @@ Ligature2: "'liga' Standardligaturen 1" P a g e u p
 EndChar
 
 StartChar: P_a_g_e_d_o_w_n
-Encoding: 65600 -1 408
+Encoding: 1114176 -1 408
 Width: 2380
 GlyphClass: 3
 Flags: MW
@@ -19580,7 +19580,7 @@ Ligature2: "'liga' Standardligaturen 1" P a g e d o w n
 EndChar
 
 StartChar: uniE138
-Encoding: 65601 -1 409
+Encoding: 1114177 -1 409
 Width: 942
 Flags: MW
 LayerCount: 3
@@ -19622,7 +19622,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE139
-Encoding: 65602 -1 410
+Encoding: 1114178 -1 410
 Width: 942
 Flags: MW
 LayerCount: 3
@@ -19657,7 +19657,7 @@ Refer: 409 -1 N 1 0 0 1 -80 0 2
 EndChar
 
 StartChar: uniE13A
-Encoding: 65603 -1 411
+Encoding: 1114179 -1 411
 Width: 942
 Flags: MW
 LayerCount: 3
@@ -19686,7 +19686,7 @@ Refer: 409 -1 N 1 0 0 1 -80 0 2
 EndChar
 
 StartChar: uniE13C
-Encoding: 65604 -1 412
+Encoding: 1114180 -1 412
 Width: 942
 Flags: MW
 LayerCount: 3
@@ -19715,7 +19715,7 @@ Refer: 409 -1 N 1 0 0 1 -80 0 2
 EndChar
 
 StartChar: uniE13D
-Encoding: 65605 -1 413
+Encoding: 1114181 -1 413
 Width: 942
 Flags: MW
 LayerCount: 3
@@ -19738,7 +19738,7 @@ Refer: 409 -1 N 1 0 0 1 -80 0 2
 EndChar
 
 StartChar: W_i_n_d_o_w_s
-Encoding: 65606 -1 414
+Encoding: 1114182 -1 414
 Width: 1470
 GlyphClass: 3
 Flags: MW
@@ -19788,7 +19788,7 @@ Ligature2: "'liga' Standardligaturen 1" W i n d o w s
 EndChar
 
 StartChar: _key
-Encoding: 65607 -1 415
+Encoding: 1114183 -1 415
 Width: 1100
 Flags: W
 LayerCount: 3

--- a/sources/LibertinusMono-Regular.sfd
+++ b/sources/LibertinusMono-Regular.sfd
@@ -77,7 +77,7 @@ EndShort
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
 OtfFeatName: 'ss01' 1033 "Low diaeresis 'A', 'E', 'O'"
 OtfFeatName: 'ss07' 1033 "Swap 'Eng' forms"
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 10
@@ -223,7 +223,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 65542 614
+BeginChars: 1114118 614
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -17397,7 +17397,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65536 -1 608
+Encoding: 1114112 -1 608
 Width: 640
 VWidth: 0
 GlyphClass: 2
@@ -17448,7 +17448,7 @@ Substitution2: "'ss07' Swap Eng styles-1" Eng
 EndChar
 
 StartChar: Adieresis.ss01
-Encoding: 65537 -1 609
+Encoding: 1114113 -1 609
 Width: 640
 Flags: W
 LayerCount: 2
@@ -17495,7 +17495,7 @@ Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind."
 EndChar
 
 StartChar: Odieresis.ss01
-Encoding: 65538 -1 610
+Encoding: 1114114 -1 610
 Width: 640
 Flags: W
 LayerCount: 2
@@ -17528,7 +17528,7 @@ Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind."
 EndChar
 
 StartChar: Udieresis.ss01
-Encoding: 65539 -1 611
+Encoding: 1114115 -1 611
 Width: 640
 Flags: W
 LayerCount: 2
@@ -17571,7 +17571,7 @@ Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind."
 EndChar
 
 StartChar: zero.slash
-Encoding: 65540 -1 612
+Encoding: 1114116 -1 612
 Width: 640
 Flags: W
 LayerCount: 2
@@ -17607,7 +17607,7 @@ EndSplineSet
 EndChar
 
 StartChar: .notdef
-Encoding: 65541 -1 613
+Encoding: 1114117 -1 613
 Width: 640
 Flags: W
 LayerCount: 2

--- a/sources/LibertinusSans-Bold.sfd
+++ b/sources/LibertinusSans-Bold.sfd
@@ -139,7 +139,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  35 c d e o q ccedilla eogonek oe ohorn
  70 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent uni022F
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSans-Bold.sfd
+++ b/sources/LibertinusSans-Bold.sfd
@@ -150,7 +150,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 76 {} 80 {} 0 {} 80 {} 40 {} 0 {} 88 {} 0 {} 0 {} 55 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -20 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -44 {} -24 {} 0 {} -61 {} -44 {} -71 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -80 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} -5 {} -34 {} 37 {} 0 {} 10 {} 10 {} 0 {} -29 {} -29 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 15 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 0 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} 0 {} 0 {} -20 {} -20 {} -20 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} -24 {} -40 {} -10 {} 7 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -65 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} 0 {} -12 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -308 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -17 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 12 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
 GaspTable: 3 8 2 17 1 65535 3 0
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 7
@@ -278,7 +278,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "acute" "'mark' Mark Positioning lookup 5" "above" "'mark' Mark Positioning lookup 4" "top_punkt" "'mark' Mark Positioning lookup 4" "below" "'mark' Mark Positioning lookup 3" "cedilla" "'mark' Mark Positioning lookup 2" "ogonek" "'mark' Mark Positioning lookup 1" "middle" "'mark' Mark Positioning in Hebrew lookup 0"
-BeginChars: 65909 2583
+BeginChars: 1114485 2583
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -8107,7 +8107,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Adieresis.alt
-Encoding: 65536 -1 339
+Encoding: 1114112 -1 339
 Width: 701
 GlyphClass: 2
 Flags: MW
@@ -8484,7 +8484,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Odieresis.alt
-Encoding: 65537 -1 357
+Encoding: 1114113 -1 357
 Width: 799
 GlyphClass: 2
 Flags: MW
@@ -8609,7 +8609,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Udieresis.alt
-Encoding: 65538 -1 363
+Encoding: 1114114 -1 363
 Width: 719
 GlyphClass: 2
 Flags: MW
@@ -25627,7 +25627,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenleft.sc
-Encoding: 65539 -1 1215
+Encoding: 1114115 -1 1215
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -25646,7 +25646,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: parenright.sc
-Encoding: 65540 -1 1216
+Encoding: 1114116 -1 1216
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -25665,7 +25665,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketleft.sc
-Encoding: 65541 -1 1217
+Encoding: 1114117 -1 1217
 Width: 409
 GlyphClass: 2
 Flags: MW
@@ -25686,7 +25686,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketright.sc
-Encoding: 65542 -1 1218
+Encoding: 1114118 -1 1218
 Width: 409
 GlyphClass: 2
 Flags: MW
@@ -25707,7 +25707,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceleft.sc
-Encoding: 65543 -1 1219
+Encoding: 1114119 -1 1219
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -25736,7 +25736,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceright.sc
-Encoding: 65544 -1 1220
+Encoding: 1114120 -1 1220
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -25765,7 +25765,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: exclamdown.sc
-Encoding: 65545 -1 1221
+Encoding: 1114121 -1 1221
 Width: 270
 GlyphClass: 2
 Flags: MW
@@ -25795,7 +25795,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: questiondown.sc
-Encoding: 65546 -1 1222
+Encoding: 1114122 -1 1222
 Width: 464
 GlyphClass: 2
 Flags: MW
@@ -25833,7 +25833,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotleft.sc
-Encoding: 65547 -1 1223
+Encoding: 1114123 -1 1223
 Width: 555
 GlyphClass: 2
 Flags: MW
@@ -25844,7 +25844,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotright.sc
-Encoding: 65548 -1 1224
+Encoding: 1114124 -1 1224
 Width: 555
 GlyphClass: 2
 Flags: MW
@@ -25855,7 +25855,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglleft.sc
-Encoding: 65549 -1 1225
+Encoding: 1114125 -1 1225
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -25866,7 +25866,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglright.sc
-Encoding: 65550 -1 1226
+Encoding: 1114126 -1 1226
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -25877,7 +25877,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_f
-Encoding: 65551 -1 1227
+Encoding: 1114127 -1 1227
 Width: 687
 GlyphClass: 3
 Flags: MW
@@ -25944,7 +25944,7 @@ LCarets2: 1 322
 EndChar
 
 StartChar: f_i
-Encoding: 65552 -1 1228
+Encoding: 1114128 -1 1228
 Width: 662
 Flags: MW
 AnchorPoint: "below" 132 -111 basechar 0
@@ -25956,7 +25956,7 @@ LCarets2: 1 338
 EndChar
 
 StartChar: f_l
-Encoding: 65553 -1 1229
+Encoding: 1114129 -1 1229
 Width: 624
 Flags: MW
 LayerCount: 2
@@ -25967,7 +25967,7 @@ LCarets2: 1 333
 EndChar
 
 StartChar: f_f_i
-Encoding: 65554 -1 1230
+Encoding: 1114130 -1 1230
 Width: 975
 Flags: MW
 LayerCount: 2
@@ -25978,7 +25978,7 @@ LCarets2: 2 327 675
 EndChar
 
 StartChar: f_f_l
-Encoding: 65555 -1 1231
+Encoding: 1114131 -1 1231
 Width: 992
 Flags: MW
 LayerCount: 2
@@ -25989,7 +25989,7 @@ LCarets2: 2 326 675
 EndChar
 
 StartChar: longs_t
-Encoding: 65556 -1 1232
+Encoding: 1114132 -1 1232
 Width: 630
 Flags: MW
 LayerCount: 2
@@ -26000,7 +26000,7 @@ LCarets2: 1 265
 EndChar
 
 StartChar: .notdef
-Encoding: 65557 -1 1233
+Encoding: 1114133 -1 1233
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -27008,7 +27008,7 @@ EndSplineSet
 EndChar
 
 StartChar: Yen.fitted
-Encoding: 65558 -1 1281
+Encoding: 1114134 -1 1281
 Width: 556
 GlyphClass: 2
 Flags: MW
@@ -27056,7 +27056,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.alt
-Encoding: 65559 -1 1282
+Encoding: 1114135 -1 1282
 Width: 585
 Flags: MW
 AnchorPoint: "top_punkt" 318 553 basechar 0
@@ -27127,7 +27127,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE01F
-Encoding: 65560 -1 1286
+Encoding: 1114136 -1 1286
 Width: 291
 Flags: MW
 LayerCount: 2
@@ -27152,7 +27152,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.oldstyle
-Encoding: 65561 -1 1287
+Encoding: 1114137 -1 1287
 Width: 544
 GlyphClass: 2
 Flags: MW
@@ -27173,7 +27173,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.oldstyle
-Encoding: 65562 -1 1288
+Encoding: 1114138 -1 1288
 Width: 439
 GlyphClass: 2
 Flags: MW
@@ -27400,7 +27400,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE001
-Encoding: 65563 -1 1290
+Encoding: 1114139 -1 1290
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -27454,7 +27454,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE002
-Encoding: 65564 -1 1291
+Encoding: 1114140 -1 1291
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -27505,7 +27505,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE003
-Encoding: 65565 -1 1292
+Encoding: 1114141 -1 1292
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -27761,7 +27761,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE004
-Encoding: 65566 -1 1294
+Encoding: 1114142 -1 1294
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -27970,7 +27970,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE005
-Encoding: 65567 -1 1298
+Encoding: 1114143 -1 1298
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -27995,7 +27995,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE006
-Encoding: 65568 -1 1299
+Encoding: 1114144 -1 1299
 Width: 1065
 Flags: MW
 LayerCount: 2
@@ -28014,7 +28014,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE007
-Encoding: 65569 -1 1300
+Encoding: 1114145 -1 1300
 Width: 2082
 Flags: MW
 LayerCount: 2
@@ -28033,7 +28033,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE008
-Encoding: 65570 -1 1301
+Encoding: 1114146 -1 1301
 Width: 6272
 Flags: MW
 LayerCount: 2
@@ -28098,7 +28098,7 @@ EndSplineSet
 EndChar
 
 StartChar: s_t
-Encoding: 65571 -1 1302
+Encoding: 1114147 -1 1302
 Width: 680
 GlyphClass: 3
 Flags: MW
@@ -29782,7 +29782,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.fitted
-Encoding: 65572 -1 1368
+Encoding: 1114148 -1 1368
 Width: 437
 GlyphClass: 2
 Flags: MW
@@ -29793,7 +29793,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.fitted
-Encoding: 65573 -1 1369
+Encoding: 1114149 -1 1369
 Width: 494
 GlyphClass: 2
 Flags: MW
@@ -29804,7 +29804,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.fitted
-Encoding: 65574 -1 1370
+Encoding: 1114150 -1 1370
 Width: 506
 GlyphClass: 2
 Flags: MW
@@ -29815,7 +29815,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.fitted
-Encoding: 65575 -1 1371
+Encoding: 1114151 -1 1371
 Width: 542
 GlyphClass: 2
 Flags: MW
@@ -29826,7 +29826,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.fitted
-Encoding: 65576 -1 1372
+Encoding: 1114152 -1 1372
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -29837,7 +29837,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.fitted
-Encoding: 65577 -1 1373
+Encoding: 1114153 -1 1373
 Width: 515
 GlyphClass: 2
 Flags: MW
@@ -29848,7 +29848,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.fitted
-Encoding: 65578 -1 1374
+Encoding: 1114154 -1 1374
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -29858,7 +29858,7 @@ Refer: 2038 56 N 1 0 0 1 -7 0 2
 EndChar
 
 StartChar: two.oldstyle
-Encoding: 65579 -1 1375
+Encoding: 1114155 -1 1375
 Width: 470
 GlyphClass: 2
 Flags: MW
@@ -29890,7 +29890,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.oldstyle
-Encoding: 65580 -1 1376
+Encoding: 1114156 -1 1376
 Width: 504
 GlyphClass: 2
 Flags: MW
@@ -39549,7 +39549,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_t
-Encoding: 65581 -1 1732
+Encoding: 1114157 -1 1732
 Width: 690
 GlyphClass: 3
 Flags: MW
@@ -39683,7 +39683,7 @@ Colour: ffffff
 EndChar
 
 StartChar: zero.slash.fitted
-Encoding: 65582 -1 1736
+Encoding: 1114158 -1 1736
 Width: 532
 GlyphClass: 2
 Flags: MW
@@ -39718,7 +39718,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Q.u
-Encoding: 65583 -1 1737
+Encoding: 1114159 -1 1737
 Width: 799
 GlyphClass: 2
 LigCaretCntFixed: 1
@@ -39746,7 +39746,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: zero.fitted
-Encoding: 65584 -1 1738
+Encoding: 1114160 -1 1738
 Width: 532
 GlyphClass: 2
 Flags: MW
@@ -39769,7 +39769,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.fitted
-Encoding: 65585 -1 1740
+Encoding: 1114161 -1 1740
 Width: 448
 GlyphClass: 2
 Flags: MW
@@ -39780,7 +39780,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.fitted
-Encoding: 65586 -1 1741
+Encoding: 1114162 -1 1741
 Width: 528
 GlyphClass: 2
 Flags: MW
@@ -39791,7 +39791,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Euro.fitted
-Encoding: 65587 -1 1742
+Encoding: 1114163 -1 1742
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -39836,7 +39836,7 @@ EndSplineSet
 EndChar
 
 StartChar: k.sc
-Encoding: 65588 -1 1743
+Encoding: 1114164 -1 1743
 Width: 596
 GlyphClass: 2
 Flags: MW
@@ -39877,7 +39877,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.sc
-Encoding: 65589 -1 1744
+Encoding: 1114165 -1 1744
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -39910,7 +39910,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.sc
-Encoding: 65590 -1 1745
+Encoding: 1114166 -1 1745
 Width: 562
 GlyphClass: 2
 Flags: MW
@@ -39950,7 +39950,7 @@ EndSplineSet
 EndChar
 
 StartChar: c.sc
-Encoding: 65591 -1 1746
+Encoding: 1114167 -1 1746
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -39980,7 +39980,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.sc
-Encoding: 65592 -1 1747
+Encoding: 1114168 -1 1747
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -40012,7 +40012,7 @@ EndSplineSet
 EndChar
 
 StartChar: e.sc
-Encoding: 65593 -1 1748
+Encoding: 1114169 -1 1748
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -40058,7 +40058,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.sc
-Encoding: 65594 -1 1749
+Encoding: 1114170 -1 1749
 Width: 494
 GlyphClass: 2
 Flags: MW
@@ -40099,7 +40099,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.sc
-Encoding: 65595 -1 1750
+Encoding: 1114171 -1 1750
 Width: 576
 GlyphClass: 2
 Flags: MW
@@ -40137,7 +40137,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.sc
-Encoding: 65596 -1 1751
+Encoding: 1114172 -1 1751
 Width: 639
 GlyphClass: 2
 Flags: MW
@@ -40184,7 +40184,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.sc
-Encoding: 65597 -1 1752
+Encoding: 1114173 -1 1752
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -40212,7 +40212,7 @@ EndSplineSet
 EndChar
 
 StartChar: j.sc
-Encoding: 65598 -1 1753
+Encoding: 1114174 -1 1753
 Width: 363
 GlyphClass: 2
 Flags: MW
@@ -40243,7 +40243,7 @@ EndSplineSet
 EndChar
 
 StartChar: l.sc
-Encoding: 65599 -1 1754
+Encoding: 1114175 -1 1754
 Width: 463
 GlyphClass: 2
 Flags: MW
@@ -40277,7 +40277,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.sc
-Encoding: 65600 -1 1755
+Encoding: 1114176 -1 1755
 Width: 756
 GlyphClass: 2
 Flags: MW
@@ -40309,7 +40309,7 @@ EndSplineSet
 EndChar
 
 StartChar: n.sc
-Encoding: 65601 -1 1756
+Encoding: 1114177 -1 1756
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -40347,7 +40347,7 @@ EndSplineSet
 EndChar
 
 StartChar: o.sc
-Encoding: 65602 -1 1757
+Encoding: 1114178 -1 1757
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -40370,7 +40370,7 @@ EndSplineSet
 EndChar
 
 StartChar: p.sc
-Encoding: 65603 -1 1758
+Encoding: 1114179 -1 1758
 Width: 515
 GlyphClass: 2
 Flags: MW
@@ -40407,7 +40407,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc
-Encoding: 65604 -1 1759
+Encoding: 1114180 -1 1759
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -40436,7 +40436,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: r.sc
-Encoding: 65605 -1 1760
+Encoding: 1114181 -1 1760
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -40478,7 +40478,7 @@ EndSplineSet
 EndChar
 
 StartChar: s.sc
-Encoding: 65606 -1 1761
+Encoding: 1114182 -1 1761
 Width: 442
 GlyphClass: 2
 Flags: MW
@@ -40511,7 +40511,7 @@ EndSplineSet
 EndChar
 
 StartChar: t.sc
-Encoding: 65607 -1 1762
+Encoding: 1114183 -1 1762
 Width: 508
 GlyphClass: 2
 Flags: MW
@@ -40544,7 +40544,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.sc
-Encoding: 65608 -1 1763
+Encoding: 1114184 -1 1763
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -40579,7 +40579,7 @@ EndSplineSet
 EndChar
 
 StartChar: v.sc
-Encoding: 65609 -1 1764
+Encoding: 1114185 -1 1764
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -40605,7 +40605,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.sc
-Encoding: 65610 -1 1765
+Encoding: 1114186 -1 1765
 Width: 844
 GlyphClass: 2
 Flags: MW
@@ -40639,7 +40639,7 @@ EndSplineSet
 EndChar
 
 StartChar: x.sc
-Encoding: 65611 -1 1766
+Encoding: 1114187 -1 1766
 Width: 544
 GlyphClass: 2
 Flags: MW
@@ -40671,7 +40671,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.sc
-Encoding: 65612 -1 1767
+Encoding: 1114188 -1 1767
 Width: 483
 GlyphClass: 2
 Flags: MW
@@ -40699,7 +40699,7 @@ EndSplineSet
 EndChar
 
 StartChar: z.sc
-Encoding: 65613 -1 1768
+Encoding: 1114189 -1 1768
 Width: 501
 GlyphClass: 2
 Flags: MW
@@ -40737,7 +40737,7 @@ EndSplineSet
 EndChar
 
 StartChar: agrave.sc
-Encoding: 65614 -1 1769
+Encoding: 1114190 -1 1769
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -40749,7 +40749,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aacute.sc
-Encoding: 65615 -1 1770
+Encoding: 1114191 -1 1770
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -40761,7 +40761,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: acircumflex.sc
-Encoding: 65616 -1 1771
+Encoding: 1114192 -1 1771
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -40773,7 +40773,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: atilde.sc
-Encoding: 65617 -1 1772
+Encoding: 1114193 -1 1772
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -40785,7 +40785,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: adieresis.sc
-Encoding: 65618 -1 1773
+Encoding: 1114194 -1 1773
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -40797,7 +40797,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aring.sc
-Encoding: 65619 -1 1774
+Encoding: 1114195 -1 1774
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -40809,7 +40809,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ae.sc
-Encoding: 65620 -1 1775
+Encoding: 1114196 -1 1775
 Width: 775
 GlyphClass: 2
 Flags: MW
@@ -40863,7 +40863,7 @@ EndSplineSet
 EndChar
 
 StartChar: ccedilla.sc
-Encoding: 65621 -1 1776
+Encoding: 1114197 -1 1776
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -40902,7 +40902,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: egrave.sc
-Encoding: 65622 -1 1777
+Encoding: 1114198 -1 1777
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -40914,7 +40914,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eacute.sc
-Encoding: 65623 -1 1778
+Encoding: 1114199 -1 1778
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -40926,7 +40926,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ecircumflex.sc
-Encoding: 65624 -1 1779
+Encoding: 1114200 -1 1779
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -40938,7 +40938,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: edieresis.sc
-Encoding: 65625 -1 1780
+Encoding: 1114201 -1 1780
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -40950,7 +40950,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: igrave.sc
-Encoding: 65626 -1 1781
+Encoding: 1114202 -1 1781
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -40962,7 +40962,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: iacute.sc
-Encoding: 65627 -1 1782
+Encoding: 1114203 -1 1782
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -40974,7 +40974,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: icircumflex.sc
-Encoding: 65628 -1 1783
+Encoding: 1114204 -1 1783
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -40986,7 +40986,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: idieresis.sc
-Encoding: 65629 -1 1784
+Encoding: 1114205 -1 1784
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -40998,7 +40998,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eth.sc
-Encoding: 65630 -1 1785
+Encoding: 1114206 -1 1785
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -41036,7 +41036,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ntilde.sc
-Encoding: 65631 -1 1786
+Encoding: 1114207 -1 1786
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -41048,7 +41048,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ograve.sc
-Encoding: 65632 -1 1787
+Encoding: 1114208 -1 1787
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -41060,7 +41060,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: oacute.sc
-Encoding: 65633 -1 1788
+Encoding: 1114209 -1 1788
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -41072,7 +41072,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ocircumflex.sc
-Encoding: 65634 -1 1789
+Encoding: 1114210 -1 1789
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -41084,7 +41084,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: otilde.sc
-Encoding: 65635 -1 1790
+Encoding: 1114211 -1 1790
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -41096,7 +41096,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: odieresis.sc
-Encoding: 65636 -1 1791
+Encoding: 1114212 -1 1791
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -41108,7 +41108,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: oe.sc
-Encoding: 65637 -1 1792
+Encoding: 1114213 -1 1792
 Width: 791
 GlyphClass: 2
 Flags: MW
@@ -41155,7 +41155,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslash.sc
-Encoding: 65638 -1 1793
+Encoding: 1114214 -1 1793
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -41190,7 +41190,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ugrave.sc
-Encoding: 65639 -1 1794
+Encoding: 1114215 -1 1794
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -41202,7 +41202,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uacute.sc
-Encoding: 65640 -1 1795
+Encoding: 1114216 -1 1795
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -41214,7 +41214,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ucircumflex.sc
-Encoding: 65641 -1 1796
+Encoding: 1114217 -1 1796
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -41226,7 +41226,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: udieresis.sc
-Encoding: 65642 -1 1797
+Encoding: 1114218 -1 1797
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -41238,7 +41238,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: yacute.sc
-Encoding: 65643 -1 1798
+Encoding: 1114219 -1 1798
 Width: 483
 GlyphClass: 2
 Flags: MW
@@ -41250,7 +41250,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: thorn.sc
-Encoding: 65644 -1 1799
+Encoding: 1114220 -1 1799
 Width: 516
 GlyphClass: 2
 Flags: MW
@@ -41287,7 +41287,7 @@ EndSplineSet
 EndChar
 
 StartChar: ydieresis.sc
-Encoding: 65645 -1 1800
+Encoding: 1114221 -1 1800
 Width: 483
 GlyphClass: 2
 Flags: MW
@@ -41299,7 +41299,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ij.sc
-Encoding: 65646 -1 1801
+Encoding: 1114222 -1 1801
 Width: 597
 GlyphClass: 2
 Flags: MW
@@ -41311,7 +41311,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: germandbls.scalt
-Encoding: 65647 -1 1802
+Encoding: 1114223 -1 1802
 Width: 769
 GlyphClass: 2
 Flags: MW
@@ -41323,7 +41323,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: hyphen.sc
-Encoding: 65648 -1 1803
+Encoding: 1114224 -1 1803
 Width: 344
 GlyphClass: 2
 Flags: MW
@@ -41334,7 +41334,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ampersand.alt
-Encoding: 65649 -1 1804
+Encoding: 1114225 -1 1804
 Width: 740
 GlyphClass: 2
 Flags: MW
@@ -48216,7 +48216,7 @@ EndSplineSet
 EndChar
 
 StartChar: abreve.sc
-Encoding: 65650 -1 2009
+Encoding: 1114226 -1 2009
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -48228,7 +48228,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aogonek.sc
-Encoding: 65651 -1 2010
+Encoding: 1114227 -1 2010
 Width: 520
 GlyphClass: 2
 Flags: MW
@@ -48266,7 +48266,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: cacute.sc
-Encoding: 65652 -1 2011
+Encoding: 1114228 -1 2011
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -48278,7 +48278,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ccaron.sc
-Encoding: 65653 -1 2012
+Encoding: 1114229 -1 2012
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -48290,7 +48290,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: dcaron.sc
-Encoding: 65654 -1 2013
+Encoding: 1114230 -1 2013
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -48302,7 +48302,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eogonek.sc
-Encoding: 65655 -1 2014
+Encoding: 1114231 -1 2014
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -48354,7 +48354,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ecaron.sc
-Encoding: 65656 -1 2015
+Encoding: 1114232 -1 2015
 Width: 527
 GlyphClass: 2
 Flags: MW
@@ -48366,7 +48366,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: gbreve.sc
-Encoding: 65657 -1 2016
+Encoding: 1114233 -1 2016
 Width: 576
 GlyphClass: 2
 Flags: MW
@@ -48378,7 +48378,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lacute.sc
-Encoding: 65658 -1 2017
+Encoding: 1114234 -1 2017
 Width: 463
 GlyphClass: 2
 Flags: MW
@@ -48390,7 +48390,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lslash.sc
-Encoding: 65659 -1 2018
+Encoding: 1114235 -1 2018
 Width: 463
 GlyphClass: 2
 Flags: MW
@@ -48429,7 +48429,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: nacute.sc
-Encoding: 65660 -1 2019
+Encoding: 1114236 -1 2019
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -48441,7 +48441,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ncaron.sc
-Encoding: 65661 -1 2020
+Encoding: 1114237 -1 2020
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -48453,7 +48453,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eng.sc
-Encoding: 65662 -1 2021
+Encoding: 1114238 -1 2021
 Width: 619
 GlyphClass: 2
 Flags: MW
@@ -48495,7 +48495,7 @@ EndSplineSet
 EndChar
 
 StartChar: ohungarumlaut.sc
-Encoding: 65663 -1 2022
+Encoding: 1114239 -1 2022
 Width: 592
 GlyphClass: 2
 Flags: MW
@@ -48507,7 +48507,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: racute.sc
-Encoding: 65664 -1 2023
+Encoding: 1114240 -1 2023
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -48549,7 +48549,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: rcaron.sc
-Encoding: 65665 -1 2024
+Encoding: 1114241 -1 2024
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -48591,7 +48591,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: sacute.sc
-Encoding: 65666 -1 2025
+Encoding: 1114242 -1 2025
 Width: 442
 GlyphClass: 2
 Flags: MW
@@ -48603,7 +48603,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: scedilla.sc
-Encoding: 65667 -1 2026
+Encoding: 1114243 -1 2026
 Width: 442
 GlyphClass: 2
 Flags: MW
@@ -48643,7 +48643,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: scaron.sc
-Encoding: 65668 -1 2027
+Encoding: 1114244 -1 2027
 Width: 442
 GlyphClass: 2
 Flags: MW
@@ -48655,7 +48655,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uni0163.sc
-Encoding: 65669 -1 2028
+Encoding: 1114245 -1 2028
 Width: 508
 GlyphClass: 2
 Flags: MW
@@ -48697,7 +48697,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: tbar.sc
-Encoding: 65670 -1 2029
+Encoding: 1114246 -1 2029
 Width: 508
 GlyphClass: 2
 Flags: MW
@@ -48737,7 +48737,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: uring.sc
-Encoding: 65671 -1 2030
+Encoding: 1114247 -1 2030
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -48749,7 +48749,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uhungarumlaut.sc
-Encoding: 65672 -1 2031
+Encoding: 1114248 -1 2031
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -48761,7 +48761,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zacute.sc
-Encoding: 65673 -1 2032
+Encoding: 1114249 -1 2032
 Width: 501
 GlyphClass: 2
 Flags: MW
@@ -48773,7 +48773,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zdotaccent.sc
-Encoding: 65674 -1 2033
+Encoding: 1114250 -1 2033
 Width: 501
 GlyphClass: 2
 Flags: MW
@@ -48785,7 +48785,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zcaron.sc
-Encoding: 65675 -1 2034
+Encoding: 1114251 -1 2034
 Width: 501
 GlyphClass: 2
 Flags: MW
@@ -48797,7 +48797,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lcaron.sc
-Encoding: 65676 -1 2035
+Encoding: 1114252 -1 2035
 Width: 463
 GlyphClass: 2
 Flags: MW
@@ -48809,7 +48809,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: dcroat.sc
-Encoding: 65677 -1 2036
+Encoding: 1114253 -1 2036
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -48820,7 +48820,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: tcaron.sc
-Encoding: 65678 -1 2037
+Encoding: 1114254 -1 2037
 Width: 508
 GlyphClass: 2
 Flags: MW
@@ -49206,7 +49206,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.superior
-Encoding: 65679 -1 2050
+Encoding: 1114255 -1 2050
 Width: 435
 Flags: MW
 LayerCount: 2
@@ -49215,7 +49215,7 @@ Refer: 2305 7495 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: c.superior
-Encoding: 65680 -1 2051
+Encoding: 1114256 -1 2051
 Width: 355
 Flags: MW
 LayerCount: 2
@@ -49224,7 +49224,7 @@ Refer: 2390 7580 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: d.superior
-Encoding: 65681 -1 2052
+Encoding: 1114257 -1 2052
 Width: 425
 Flags: MW
 LayerCount: 2
@@ -49233,7 +49233,7 @@ Refer: 2306 7496 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: e.superior
-Encoding: 65682 -1 2053
+Encoding: 1114258 -1 2053
 Width: 377
 Flags: MW
 LayerCount: 2
@@ -49243,7 +49243,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f.superior
-Encoding: 65683 -1 2054
+Encoding: 1114259 -1 2054
 Width: 260
 Flags: MW
 LayerCount: 2
@@ -49252,7 +49252,7 @@ Refer: 2394 7584 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: g.superior
-Encoding: 65684 -1 2055
+Encoding: 1114260 -1 2055
 Width: 407
 Flags: MW
 LayerCount: 2
@@ -49261,7 +49261,7 @@ Refer: 2311 7501 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0C7
-Encoding: 65685 -1 2056
+Encoding: 1114261 -1 2056
 Width: 460
 Flags: MW
 LayerCount: 2
@@ -49270,7 +49270,7 @@ Refer: 1303 688 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0C8
-Encoding: 65686 -1 2057
+Encoding: 1114262 -1 2057
 Width: 271
 Flags: MW
 LayerCount: 2
@@ -49279,7 +49279,7 @@ Refer: 2332 7522 N 1 0 0 1 0 465 2
 EndChar
 
 StartChar: uniE0C9
-Encoding: 65687 -1 2058
+Encoding: 1114263 -1 2058
 Width: 256
 Flags: MW
 LayerCount: 2
@@ -49288,7 +49288,7 @@ Refer: 1304 690 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: k.superior
-Encoding: 65688 -1 2059
+Encoding: 1114264 -1 2059
 Width: 422
 Flags: MW
 LayerCount: 2
@@ -49297,7 +49297,7 @@ Refer: 2313 7503 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: m.superior
-Encoding: 65689 -1 2060
+Encoding: 1114265 -1 2060
 Width: 650
 Flags: MW
 LayerCount: 2
@@ -49306,7 +49306,7 @@ Refer: 2314 7504 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0CD
-Encoding: 65690 -1 2061
+Encoding: 1114266 -1 2061
 Width: 452
 Flags: MW
 LayerCount: 2
@@ -49315,7 +49315,7 @@ Refer: 1043 8319 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: o.superior
-Encoding: 65691 -1 2062
+Encoding: 1114267 -1 2062
 Width: 417
 Flags: MW
 LayerCount: 2
@@ -49325,7 +49325,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: p.superior
-Encoding: 65692 -1 2063
+Encoding: 1114268 -1 2063
 Width: 440
 Flags: MW
 LayerCount: 2
@@ -49334,7 +49334,7 @@ Refer: 2320 7510 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: q.superior
-Encoding: 65693 -1 2064
+Encoding: 1114269 -1 2064
 Width: 456
 GlyphClass: 2
 Flags: MW
@@ -49369,7 +49369,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0D1
-Encoding: 65694 -1 2065
+Encoding: 1114270 -1 2065
 Width: 316
 Flags: MW
 LayerCount: 2
@@ -49378,7 +49378,7 @@ Refer: 1305 691 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: t.superior
-Encoding: 65695 -1 2066
+Encoding: 1114271 -1 2066
 Width: 249
 Flags: MW
 LayerCount: 2
@@ -49387,7 +49387,7 @@ Refer: 2321 7511 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: u.superior
-Encoding: 65696 -1 2067
+Encoding: 1114272 -1 2067
 Width: 450
 Flags: MW
 LayerCount: 2
@@ -49396,7 +49396,7 @@ Refer: 2322 7512 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: v.superior
-Encoding: 65697 -1 2068
+Encoding: 1114273 -1 2068
 Width: 371
 Flags: MW
 LayerCount: 2
@@ -49405,7 +49405,7 @@ Refer: 2325 7515 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0D6
-Encoding: 65698 -1 2069
+Encoding: 1114274 -1 2069
 Width: 524
 Flags: MW
 LayerCount: 2
@@ -49414,7 +49414,7 @@ Refer: 1307 695 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0D7
-Encoding: 65699 -1 2070
+Encoding: 1114275 -1 2070
 Width: 367
 Flags: MW
 LayerCount: 2
@@ -49423,7 +49423,7 @@ Refer: 297 739 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0D8
-Encoding: 65700 -1 2071
+Encoding: 1114276 -1 2071
 Width: 371
 Flags: MW
 LayerCount: 2
@@ -49432,7 +49432,7 @@ Refer: 1308 696 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: z.superior
-Encoding: 65701 -1 2072
+Encoding: 1114277 -1 2072
 Width: 336
 Flags: MW
 LayerCount: 2
@@ -49491,7 +49491,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: zero.slash
-Encoding: 65702 -1 2074
+Encoding: 1114278 -1 2074
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49525,7 +49525,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.sc
-Encoding: 65703 -1 2075
+Encoding: 1114279 -1 2075
 Width: 599
 GlyphClass: 2
 Flags: MW
@@ -49567,7 +49567,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.superior
-Encoding: 65704 -1 2076
+Encoding: 1114280 -1 2076
 Width: 372
 Flags: MW
 LayerCount: 2
@@ -49577,7 +49577,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE100
-Encoding: 65705 -1 2077
+Encoding: 1114281 -1 2077
 Width: 633
 Flags: MW
 LayerCount: 2
@@ -49597,7 +49597,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.oldstyle
-Encoding: 65706 -1 2078
+Encoding: 1114282 -1 2078
 Width: 526
 GlyphClass: 2
 Flags: MW
@@ -49607,7 +49607,7 @@ Refer: 13 52 N 1 0 0 1 8 -162 2
 EndChar
 
 StartChar: five.oldstyle
-Encoding: 65707 -1 2079
+Encoding: 1114283 -1 2079
 Width: 489
 GlyphClass: 2
 Flags: MW
@@ -49618,7 +49618,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.oldstyle
-Encoding: 65708 -1 2080
+Encoding: 1114284 -1 2080
 Width: 525
 GlyphClass: 2
 Flags: MW
@@ -49629,7 +49629,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.oldstyle
-Encoding: 65709 -1 2081
+Encoding: 1114285 -1 2081
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -49640,7 +49640,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.oldstyle
-Encoding: 65710 -1 2082
+Encoding: 1114286 -1 2082
 Width: 514
 Flags: MW
 LayerCount: 2
@@ -49649,7 +49649,7 @@ Refer: 2038 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: nine.oldstyle
-Encoding: 65711 -1 2083
+Encoding: 1114287 -1 2083
 Width: 468
 GlyphClass: 2
 Flags: MW
@@ -49660,7 +49660,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0F9
-Encoding: 65712 -1 2084
+Encoding: 1114288 -1 2084
 Width: 623
 Flags: MW
 LayerCount: 2
@@ -49672,7 +49672,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0FB
-Encoding: 65713 -1 2085
+Encoding: 1114289 -1 2085
 Width: 640
 Flags: MW
 LayerCount: 2
@@ -49684,7 +49684,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t_t
-Encoding: 65714 -1 2086
+Encoding: 1114290 -1 2086
 Width: 690
 GlyphClass: 3
 Flags: MW
@@ -49741,7 +49741,7 @@ LCarets2: 1 306
 EndChar
 
 StartChar: c_t
-Encoding: 65715 -1 2087
+Encoding: 1114291 -1 2087
 Width: 848
 GlyphClass: 3
 Flags: MW
@@ -49845,7 +49845,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.taboldstyle
-Encoding: 65716 -1 2090
+Encoding: 1114292 -1 2090
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49866,7 +49866,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.taboldstyle
-Encoding: 65717 -1 2091
+Encoding: 1114293 -1 2091
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49877,7 +49877,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.taboldstyle
-Encoding: 65718 -1 2092
+Encoding: 1114294 -1 2092
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49888,7 +49888,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.taboldstyle
-Encoding: 65719 -1 2093
+Encoding: 1114295 -1 2093
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49899,7 +49899,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.taboldstyle
-Encoding: 65720 -1 2094
+Encoding: 1114296 -1 2094
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49910,7 +49910,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.taboldstyle
-Encoding: 65721 -1 2095
+Encoding: 1114297 -1 2095
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49921,7 +49921,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.taboldstyle
-Encoding: 65722 -1 2096
+Encoding: 1114298 -1 2096
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49932,7 +49932,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.taboldstyle
-Encoding: 65723 -1 2097
+Encoding: 1114299 -1 2097
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49943,7 +49943,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.taboldstyle
-Encoding: 65724 -1 2098
+Encoding: 1114300 -1 2098
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -49954,7 +49954,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.taboldstyle
-Encoding: 65725 -1 2099
+Encoding: 1114301 -1 2099
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -50007,7 +50007,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE104
-Encoding: 65726 -1 2101
+Encoding: 1114302 -1 2101
 Width: 611
 Flags: MW
 LayerCount: 2
@@ -50104,7 +50104,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE105
-Encoding: 65727 -1 2102
+Encoding: 1114303 -1 2102
 Width: 835
 Flags: MW
 LayerCount: 2
@@ -50245,7 +50245,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE106
-Encoding: 65728 -1 2103
+Encoding: 1114304 -1 2103
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -50337,7 +50337,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE107
-Encoding: 65729 -1 2104
+Encoding: 1114305 -1 2104
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -50418,7 +50418,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni1E9E.alt
-Encoding: 65730 -1 2105
+Encoding: 1114306 -1 2105
 Width: 947
 GlyphClass: 2
 Flags: MW
@@ -50430,7 +50430,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE00B
-Encoding: 65731 -1 2106
+Encoding: 1114307 -1 2106
 Width: 407
 Flags: MW
 LayerCount: 2
@@ -50729,7 +50729,7 @@ EndSplineSet
 EndChar
 
 StartChar: hyphen.cap
-Encoding: 65732 -1 2113
+Encoding: 1114308 -1 2113
 Width: 344
 GlyphClass: 2
 Flags: MW
@@ -50764,7 +50764,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE101
-Encoding: 65733 -1 2115
+Encoding: 1114309 -1 2115
 Width: 759
 Flags: MW
 LayerCount: 2
@@ -50784,7 +50784,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE148
-Encoding: 65734 -1 2116
+Encoding: 1114310 -1 2116
 Width: 372
 Flags: MW
 LayerCount: 2
@@ -50793,7 +50793,7 @@ Refer: 313 170 N 1 0 0 1 0 -466 2
 EndChar
 
 StartChar: b.inferior
-Encoding: 65735 -1 2117
+Encoding: 1114311 -1 2117
 Width: 435
 GlyphClass: 2
 Flags: MW
@@ -50804,7 +50804,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: c.inferior
-Encoding: 65736 -1 2118
+Encoding: 1114312 -1 2118
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -50815,7 +50815,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: d.inferior
-Encoding: 65737 -1 2119
+Encoding: 1114313 -1 2119
 Width: 425
 GlyphClass: 2
 Flags: MW
@@ -50826,7 +50826,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f.inferior
-Encoding: 65738 -1 2120
+Encoding: 1114314 -1 2120
 Width: 260
 GlyphClass: 2
 Flags: MW
@@ -50837,7 +50837,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: g.inferior
-Encoding: 65739 -1 2121
+Encoding: 1114315 -1 2121
 Width: 407
 GlyphClass: 2
 Flags: MW
@@ -50897,7 +50897,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: h.inferior
-Encoding: 65740 -1 2122
+Encoding: 1114316 -1 2122
 Width: 460
 GlyphClass: 2
 Flags: MW
@@ -50908,7 +50908,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: i.inferior
-Encoding: 65741 -1 2123
+Encoding: 1114317 -1 2123
 Width: 271
 GlyphClass: 2
 Flags: MW
@@ -50919,7 +50919,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: j.inferior
-Encoding: 65742 -1 2124
+Encoding: 1114318 -1 2124
 Width: 256
 GlyphClass: 2
 Flags: MW
@@ -50958,7 +50958,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: k.inferior
-Encoding: 65743 -1 2125
+Encoding: 1114319 -1 2125
 Width: 422
 GlyphClass: 2
 Flags: MW
@@ -50969,7 +50969,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: l.inferior
-Encoding: 65744 -1 2126
+Encoding: 1114320 -1 2126
 Width: 261
 GlyphClass: 2
 Flags: MW
@@ -50980,7 +50980,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: m.inferior
-Encoding: 65745 -1 2127
+Encoding: 1114321 -1 2127
 Width: 650
 GlyphClass: 2
 Flags: MW
@@ -50991,7 +50991,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: n.inferior
-Encoding: 65746 -1 2128
+Encoding: 1114322 -1 2128
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -51002,7 +51002,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: p.inferior
-Encoding: 65747 -1 2129
+Encoding: 1114323 -1 2129
 Width: 440
 GlyphClass: 2
 Flags: MW
@@ -51013,7 +51013,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: q.inferior
-Encoding: 65748 -1 2130
+Encoding: 1114324 -1 2130
 Width: 456
 GlyphClass: 2
 Flags: MW
@@ -51024,7 +51024,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: r.inferior
-Encoding: 65749 -1 2131
+Encoding: 1114325 -1 2131
 Width: 316
 GlyphClass: 2
 Flags: MW
@@ -51035,7 +51035,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: s.inferior
-Encoding: 65750 -1 2132
+Encoding: 1114326 -1 2132
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -51046,7 +51046,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t.inferior
-Encoding: 65751 -1 2133
+Encoding: 1114327 -1 2133
 Width: 249
 GlyphClass: 2
 Flags: MW
@@ -51057,7 +51057,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: u.inferior
-Encoding: 65752 -1 2134
+Encoding: 1114328 -1 2134
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -51068,7 +51068,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: v.inferior
-Encoding: 65753 -1 2135
+Encoding: 1114329 -1 2135
 Width: 371
 GlyphClass: 2
 Flags: MW
@@ -51079,7 +51079,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: w.inferior
-Encoding: 65754 -1 2136
+Encoding: 1114330 -1 2136
 Width: 524
 GlyphClass: 2
 Flags: MW
@@ -51090,7 +51090,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: y.inferior
-Encoding: 65755 -1 2137
+Encoding: 1114331 -1 2137
 Width: 371
 GlyphClass: 2
 Flags: MW
@@ -51101,7 +51101,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: z.inferior
-Encoding: 65756 -1 2138
+Encoding: 1114332 -1 2138
 Width: 336
 GlyphClass: 2
 Flags: MW
@@ -51141,7 +51141,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE06B
-Encoding: 65757 -1 2140
+Encoding: 1114333 -1 2140
 Width: 516
 Flags: MW
 LayerCount: 2
@@ -51280,7 +51280,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE128
-Encoding: 65758 -1 2146
+Encoding: 1114334 -1 2146
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -51300,7 +51300,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE129
-Encoding: 65759 -1 2147
+Encoding: 1114335 -1 2147
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -51324,7 +51324,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE12A
-Encoding: 65760 -1 2148
+Encoding: 1114336 -1 2148
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -51718,7 +51718,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni021B.sc
-Encoding: 65761 -1 2158
+Encoding: 1114337 -1 2158
 Width: 508
 GlyphClass: 2
 Flags: MW
@@ -51730,7 +51730,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uni0219.sc
-Encoding: 65762 -1 2159
+Encoding: 1114338 -1 2159
 Width: 442
 GlyphClass: 2
 Flags: MW
@@ -51742,7 +51742,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: idotaccent.sc
-Encoding: 65763 -1 2160
+Encoding: 1114339 -1 2160
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -51754,7 +51754,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE130
-Encoding: 65764 -1 2161
+Encoding: 1114340 -1 2161
 Width: 344
 Flags: MW
 LayerCount: 2
@@ -51798,7 +51798,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.alt
-Encoding: 65765 -1 2163
+Encoding: 1114341 -1 2163
 Width: 591
 GlyphClass: 2
 Flags: MW
@@ -52049,7 +52049,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0CB
-Encoding: 65766 -1 2172
+Encoding: 1114342 -1 2172
 Width: 261
 Flags: MW
 LayerCount: 2
@@ -52058,7 +52058,7 @@ Refer: 285 737 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: grave.cap
-Encoding: 65767 -1 2173
+Encoding: 1114343 -1 2173
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52078,7 +52078,7 @@ EndSplineSet
 EndChar
 
 StartChar: acute.cap
-Encoding: 65768 -1 2174
+Encoding: 1114344 -1 2174
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52098,7 +52098,7 @@ EndSplineSet
 EndChar
 
 StartChar: circumflex.cap
-Encoding: 65769 -1 2175
+Encoding: 1114345 -1 2175
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52118,7 +52118,7 @@ EndSplineSet
 EndChar
 
 StartChar: caron.cap
-Encoding: 65770 -1 2176
+Encoding: 1114346 -1 2176
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52138,7 +52138,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cap
-Encoding: 65771 -1 2177
+Encoding: 1114347 -1 2177
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52157,7 +52157,7 @@ EndSplineSet
 EndChar
 
 StartChar: hungarumlaut.cap
-Encoding: 65772 -1 2178
+Encoding: 1114348 -1 2178
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52186,7 +52186,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni030F.cap
-Encoding: 65773 -1 2179
+Encoding: 1114349 -1 2179
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52219,7 +52219,7 @@ EndSplineSet
 EndChar
 
 StartChar: breveinvertedcmb.cap
-Encoding: 65774 -1 2180
+Encoding: 1114350 -1 2180
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52238,7 +52238,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyrcap
-Encoding: 65775 -1 2181
+Encoding: 1114351 -1 2181
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52261,7 +52261,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyr
-Encoding: 65776 -1 2182
+Encoding: 1114352 -1 2182
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52285,7 +52285,7 @@ EndSplineSet
 EndChar
 
 StartChar: dieresis.cap
-Encoding: 65777 -1 2183
+Encoding: 1114353 -1 2183
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52307,7 +52307,7 @@ EndSplineSet
 EndChar
 
 StartChar: hookabovecomb.cap
-Encoding: 65778 -1 2184
+Encoding: 1114354 -1 2184
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -52377,7 +52377,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE351
-Encoding: 65779 -1 2186
+Encoding: 1114355 -1 2186
 Width: 243
 GlyphClass: 4
 Flags: MW
@@ -53522,7 +53522,7 @@ EndSplineSet
 EndChar
 
 StartChar: NameMe.58212
-Encoding: 65780 -1 2231
+Encoding: 1114356 -1 2231
 Width: 0
 Flags: MW
 LayerCount: 2
@@ -53531,7 +53531,7 @@ Refer: 655 775 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: dotaccent.cap
-Encoding: 65781 -1 2232
+Encoding: 1114357 -1 2232
 Width: 0
 GlyphClass: 4
 Flags: M
@@ -53541,7 +53541,7 @@ Refer: 655 775 N 1 0 0 1 -24 199 2
 EndChar
 
 StartChar: uniE01E
-Encoding: 65782 -1 2233
+Encoding: 1114358 -1 2233
 Width: 892
 Flags: MW
 AnchorPoint: "cedilla" 146 9 basechar 0
@@ -61003,7 +61003,7 @@ Refer: 2321 7511 N 1 0 0 1 0 -466 2
 EndChar
 
 StartChar: uniE0D2
-Encoding: 65783 -1 2432
+Encoding: 1114359 -1 2432
 Width: 307
 Flags: MW
 LayerCount: 2
@@ -61012,7 +61012,7 @@ Refer: 292 738 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0DA
-Encoding: 65784 -1 2433
+Encoding: 1114360 -1 2433
 Width: 377
 Flags: MW
 LayerCount: 2
@@ -61021,7 +61021,7 @@ Refer: 2308 7498 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0DB
-Encoding: 65785 -1 2434
+Encoding: 1114361 -1 2434
 Width: 451
 Flags: MW
 LayerCount: 2
@@ -61030,7 +61030,7 @@ Refer: 2278 7468 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0DC
-Encoding: 65786 -1 2435
+Encoding: 1114362 -1 2435
 Width: 511
 Flags: MW
 LayerCount: 2
@@ -61039,7 +61039,7 @@ Refer: 2280 7470 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0DD
-Encoding: 65787 -1 2436
+Encoding: 1114363 -1 2436
 Width: 442
 Flags: MW
 LayerCount: 2
@@ -61072,7 +61072,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0DE
-Encoding: 65788 -1 2437
+Encoding: 1114364 -1 2437
 Width: 556
 Flags: MW
 LayerCount: 2
@@ -61081,7 +61081,7 @@ Refer: 2282 7472 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0DF
-Encoding: 65789 -1 2438
+Encoding: 1114365 -1 2438
 Width: 458
 Flags: MW
 LayerCount: 2
@@ -61090,7 +61090,7 @@ Refer: 2283 7473 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E0
-Encoding: 65790 -1 2439
+Encoding: 1114366 -1 2439
 Width: 414
 Flags: MW
 LayerCount: 2
@@ -61129,7 +61129,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0E1
-Encoding: 65791 -1 2440
+Encoding: 1114367 -1 2440
 Width: 522
 Flags: MW
 LayerCount: 2
@@ -61138,7 +61138,7 @@ Refer: 2285 7475 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E2
-Encoding: 65792 -1 2441
+Encoding: 1114368 -1 2441
 Width: 592
 Flags: MW
 LayerCount: 2
@@ -61147,7 +61147,7 @@ Refer: 2286 7476 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E3
-Encoding: 65793 -1 2442
+Encoding: 1114369 -1 2442
 Width: 321
 Flags: MW
 LayerCount: 2
@@ -61156,7 +61156,7 @@ Refer: 2287 7477 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E4
-Encoding: 65794 -1 2443
+Encoding: 1114370 -1 2443
 Width: 320
 Flags: MW
 LayerCount: 2
@@ -61165,7 +61165,7 @@ Refer: 2288 7478 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E5
-Encoding: 65795 -1 2444
+Encoding: 1114371 -1 2444
 Width: 577
 Flags: MW
 LayerCount: 2
@@ -61174,7 +61174,7 @@ Refer: 2289 7479 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E6
-Encoding: 65796 -1 2445
+Encoding: 1114372 -1 2445
 Width: 455
 Flags: MW
 LayerCount: 2
@@ -61183,7 +61183,7 @@ Refer: 2290 7480 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E7
-Encoding: 65797 -1 2446
+Encoding: 1114373 -1 2446
 Width: 611
 Flags: MW
 LayerCount: 2
@@ -61192,7 +61192,7 @@ Refer: 2291 7481 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E8
-Encoding: 65798 -1 2447
+Encoding: 1114374 -1 2447
 Width: 560
 Flags: MW
 LayerCount: 2
@@ -61201,7 +61201,7 @@ Refer: 2292 7482 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0E9
-Encoding: 65799 -1 2448
+Encoding: 1114375 -1 2448
 Width: 544
 Flags: MW
 LayerCount: 2
@@ -61210,7 +61210,7 @@ Refer: 2294 7484 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0EA
-Encoding: 65800 -1 2449
+Encoding: 1114376 -1 2449
 Width: 464
 Flags: MW
 LayerCount: 2
@@ -61219,7 +61219,7 @@ Refer: 2296 7486 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0EB
-Encoding: 65801 -1 2450
+Encoding: 1114377 -1 2450
 Width: 481
 Flags: MW
 LayerCount: 2
@@ -61252,7 +61252,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0EC
-Encoding: 65802 -1 2451
+Encoding: 1114378 -1 2451
 Width: 519
 Flags: MW
 LayerCount: 2
@@ -61261,7 +61261,7 @@ Refer: 2297 7487 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0ED
-Encoding: 65803 -1 2452
+Encoding: 1114379 -1 2452
 Width: 378
 Flags: MW
 LayerCount: 2
@@ -61297,7 +61297,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0EE
-Encoding: 65804 -1 2453
+Encoding: 1114380 -1 2453
 Width: 420
 Flags: MW
 LayerCount: 2
@@ -61306,7 +61306,7 @@ Refer: 2298 7488 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0EF
-Encoding: 65805 -1 2454
+Encoding: 1114381 -1 2454
 Width: 531
 Flags: MW
 LayerCount: 2
@@ -61315,7 +61315,7 @@ Refer: 2299 7489 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0F0
-Encoding: 65806 -1 2455
+Encoding: 1114382 -1 2455
 Width: 470
 Flags: MW
 LayerCount: 2
@@ -61337,7 +61337,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F1
-Encoding: 65807 -1 2456
+Encoding: 1114383 -1 2456
 Width: 705
 Flags: MW
 LayerCount: 2
@@ -61346,7 +61346,7 @@ Refer: 2300 7490 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0F2
-Encoding: 65808 -1 2457
+Encoding: 1114384 -1 2457
 Width: 517
 Flags: MW
 LayerCount: 2
@@ -61373,7 +61373,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F3
-Encoding: 65809 -1 2458
+Encoding: 1114385 -1 2458
 Width: 435
 Flags: MW
 LayerCount: 2
@@ -61396,7 +61396,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F4
-Encoding: 65810 -1 2459
+Encoding: 1114386 -1 2459
 Width: 420
 Flags: MW
 LayerCount: 2
@@ -61433,7 +61433,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE14C
-Encoding: 65811 -1 2460
+Encoding: 1114387 -1 2460
 Width: 377
 Flags: MW
 LayerCount: 2
@@ -61442,7 +61442,7 @@ Refer: 2307 7497 N 1 0 0 1 0 -466 2
 EndChar
 
 StartChar: uniE156
-Encoding: 65812 -1 2461
+Encoding: 1114388 -1 2461
 Width: 417
 Flags: MW
 LayerCount: 2
@@ -61451,7 +61451,7 @@ Refer: 329 186 N 1 0 0 1 0 -466 2
 EndChar
 
 StartChar: uniE15F
-Encoding: 65813 -1 2462
+Encoding: 1114389 -1 2462
 Width: 367
 Flags: MW
 LayerCount: 2
@@ -61460,7 +61460,7 @@ Refer: 297 739 N 1 0 0 1 0 -466 2
 EndChar
 
 StartChar: uniE1A8
-Encoding: 65814 -1 2463
+Encoding: 1114390 -1 2463
 Width: 354
 Flags: MW
 AnchorPoint: "cedilla" 184 -3 basechar 0
@@ -61497,7 +61497,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.elb
-Encoding: 65815 -1 2464
+Encoding: 1114391 -1 2464
 Width: 893
 Flags: MW
 LayerCount: 2
@@ -61548,7 +61548,7 @@ EndSplineSet
 EndChar
 
 StartChar: p.elb
-Encoding: 65816 -1 2465
+Encoding: 1114392 -1 2465
 Width: 585
 Flags: MW
 AnchorPoint: "top_punkt" 291 551 basechar 0
@@ -61584,7 +61584,7 @@ EndSplineSet
 EndChar
 
 StartChar: r.elb
-Encoding: 65817 -1 2466
+Encoding: 1114393 -1 2466
 Width: 421
 Flags: MW
 LayerCount: 2
@@ -61614,7 +61614,7 @@ EndSplineSet
 EndChar
 
 StartChar: n.elb
-Encoding: 65818 -1 2467
+Encoding: 1114394 -1 2467
 Width: 600
 Flags: MW
 AnchorPoint: "cedilla" 133 9 basechar 0
@@ -61654,7 +61654,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.elb
-Encoding: 65819 -1 2468
+Encoding: 1114395 -1 2468
 Width: 600
 Flags: MW
 AnchorPoint: "cedilla" 142 12 basechar 0
@@ -61694,7 +61694,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.elb
-Encoding: 65820 -1 2469
+Encoding: 1114396 -1 2469
 Width: 591
 Flags: MW
 LayerCount: 2
@@ -61728,7 +61728,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.elb
-Encoding: 65821 -1 2470
+Encoding: 1114397 -1 2470
 Width: 561
 Flags: MW
 AnchorPoint: "top_punkt" 240 549 basechar 0
@@ -61782,7 +61782,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.elba
-Encoding: 65822 -1 2471
+Encoding: 1114398 -1 2471
 Width: 310
 Flags: MW
 AnchorPoint: "below" 136 -107 basechar 0
@@ -61805,7 +61805,7 @@ Refer: 411 305 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: j.elb
-Encoding: 65823 -1 2472
+Encoding: 1114399 -1 2472
 Width: 350
 Flags: MW
 LayerCount: 2
@@ -61842,7 +61842,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1B4
-Encoding: 65824 -1 2473
+Encoding: 1114400 -1 2473
 Width: 429
 Flags: MW
 AnchorPoint: "ogonek" 503 -50 basechar 0
@@ -61875,7 +61875,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1B6
-Encoding: 65825 -1 2474
+Encoding: 1114401 -1 2474
 Width: 595
 Flags: MW
 AnchorPoint: "above" 262 645 basechar 0
@@ -61909,7 +61909,7 @@ EndSplineSet
 EndChar
 
 StartChar: A.elb
-Encoding: 65826 -1 2475
+Encoding: 1114402 -1 2475
 Width: 701
 Flags: MW
 AnchorPoint: "below" 272 -108 basechar 0
@@ -61939,7 +61939,7 @@ EndSplineSet
 EndChar
 
 StartChar: B.elb
-Encoding: 65827 -1 2476
+Encoding: 1114403 -1 2476
 Width: 675
 Flags: MW
 AnchorPoint: "below" 288 -108 basechar 0
@@ -61952,7 +61952,7 @@ Refer: 25 66 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: C.elb
-Encoding: 65828 -1 2477
+Encoding: 1114404 -1 2477
 Width: 706
 Flags: MW
 AnchorPoint: "below" 404 -110 basechar 0
@@ -61965,7 +61965,7 @@ Refer: 26 67 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: D.elb
-Encoding: 65829 -1 2478
+Encoding: 1114405 -1 2478
 Width: 761
 Flags: MW
 AnchorPoint: "top_punkt" 385 721 basechar 0
@@ -61978,7 +61978,7 @@ Refer: 27 68 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: E.elb
-Encoding: 65830 -1 2479
+Encoding: 1114406 -1 2479
 Width: 594
 Flags: MW
 AnchorPoint: "cedilla" 299 4 basechar 0
@@ -62022,7 +62022,7 @@ EndSplineSet
 EndChar
 
 StartChar: F.elb
-Encoding: 65831 -1 2480
+Encoding: 1114407 -1 2480
 Width: 554
 Flags: MW
 AnchorPoint: "cedilla" 155 -1 basechar 0
@@ -62063,7 +62063,7 @@ EndSplineSet
 EndChar
 
 StartChar: G.elb
-Encoding: 65832 -1 2481
+Encoding: 1114408 -1 2481
 Width: 753
 Flags: MW
 AnchorPoint: "cedilla" 374 2 basechar 0
@@ -62100,7 +62100,7 @@ EndSplineSet
 EndChar
 
 StartChar: H.elb
-Encoding: 65833 -1 2482
+Encoding: 1114409 -1 2482
 Width: 764
 Flags: MW
 AnchorPoint: "cedilla" 164 0 basechar 0
@@ -62113,7 +62113,7 @@ Refer: 2073 72 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: I.elb
-Encoding: 65834 -1 2483
+Encoding: 1114410 -1 2483
 Width: 330
 Flags: MW
 AnchorPoint: "cedilla" 168 1 basechar 0
@@ -62126,7 +62126,7 @@ Refer: 251 73 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: J.elb
-Encoding: 65835 -1 2484
+Encoding: 1114411 -1 2484
 Width: 373
 Flags: MW
 AnchorPoint: "top_punkt" 218 723 basechar 0
@@ -62156,7 +62156,7 @@ EndSplineSet
 EndChar
 
 StartChar: K.elb
-Encoding: 65836 -1 2485
+Encoding: 1114412 -1 2485
 Width: 759
 Flags: MW
 AnchorPoint: "cedilla" 148 -1 basechar 0
@@ -62186,7 +62186,7 @@ Refer: 251 73 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: L.elb
-Encoding: 65837 -1 2486
+Encoding: 1114413 -1 2486
 Width: 584
 Flags: MW
 AnchorPoint: "cedilla" 280 1 basechar 0
@@ -62219,7 +62219,7 @@ EndSplineSet
 EndChar
 
 StartChar: M.elb
-Encoding: 65838 -1 2487
+Encoding: 1114414 -1 2487
 Width: 891
 Flags: MW
 AnchorPoint: "cedilla" 97 2 basechar 0
@@ -62249,7 +62249,7 @@ EndSplineSet
 EndChar
 
 StartChar: N.elb
-Encoding: 65839 -1 2488
+Encoding: 1114415 -1 2488
 Width: 780
 Flags: MW
 AnchorPoint: "cedilla" 124 -3 basechar 0
@@ -62291,7 +62291,7 @@ EndSplineSet
 EndChar
 
 StartChar: O.elb
-Encoding: 65840 -1 2489
+Encoding: 1114416 -1 2489
 Width: 799
 Flags: MW
 AnchorPoint: "cedilla" 381 0 basechar 0
@@ -62304,7 +62304,7 @@ Refer: 257 79 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: P.elb
-Encoding: 65841 -1 2490
+Encoding: 1114417 -1 2490
 Width: 598
 Flags: MW
 AnchorPoint: "cedilla" 160 -3 basechar 0
@@ -62341,7 +62341,7 @@ EndSplineSet
 EndChar
 
 StartChar: Q.elb
-Encoding: 65842 -1 2491
+Encoding: 1114418 -1 2491
 Width: 799
 Flags: MW
 AnchorPoint: "above" 348 803 basechar 0
@@ -62352,7 +62352,7 @@ Refer: 259 81 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: R.elb
-Encoding: 65843 -1 2492
+Encoding: 1114419 -1 2492
 Width: 687
 Flags: MW
 AnchorPoint: "cedilla" 158 -1 basechar 0
@@ -62365,7 +62365,7 @@ Refer: 260 82 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: S.elb
-Encoding: 65844 -1 2493
+Encoding: 1114420 -1 2493
 Width: 542
 Flags: MW
 AnchorPoint: "cedilla" 227 2 basechar 0
@@ -62378,7 +62378,7 @@ Refer: 261 83 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: T.elb
-Encoding: 65845 -1 2494
+Encoding: 1114421 -1 2494
 Width: 602
 Flags: MW
 AnchorPoint: "cedilla" 286 1 basechar 0
@@ -62391,7 +62391,7 @@ Refer: 262 84 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: U.elb
-Encoding: 65846 -1 2495
+Encoding: 1114422 -1 2495
 Width: 719
 Flags: MW
 AnchorPoint: "cedilla" 348 4 basechar 0
@@ -62404,7 +62404,7 @@ Refer: 263 85 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: V.elb
-Encoding: 65847 -1 2496
+Encoding: 1114423 -1 2496
 Width: 672
 Flags: MW
 AnchorPoint: "cedilla" 303 3 basechar 0
@@ -62428,7 +62428,7 @@ EndSplineSet
 EndChar
 
 StartChar: W.elb
-Encoding: 65848 -1 2497
+Encoding: 1114424 -1 2497
 Width: 1043
 Flags: MW
 AnchorPoint: "cedilla" 305 0 basechar 0
@@ -62460,7 +62460,7 @@ EndSplineSet
 EndChar
 
 StartChar: X.elb
-Encoding: 65849 -1 2498
+Encoding: 1114425 -1 2498
 Width: 643
 Flags: MW
 AnchorPoint: "cedilla" 117 0 basechar 0
@@ -62491,7 +62491,7 @@ EndSplineSet
 EndChar
 
 StartChar: Y.elb
-Encoding: 65850 -1 2499
+Encoding: 1114426 -1 2499
 Width: 653
 Flags: MW
 AnchorPoint: "cedilla" 315 1 basechar 0
@@ -62504,7 +62504,7 @@ Refer: 267 89 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: Z.elb
-Encoding: 65851 -1 2500
+Encoding: 1114427 -1 2500
 Width: 645
 Flags: MW
 AnchorPoint: "cedilla" 307 4 basechar 0
@@ -62517,7 +62517,7 @@ Refer: 268 90 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: l.elb
-Encoding: 65852 -1 2501
+Encoding: 1114428 -1 2501
 Width: 304
 Flags: MW
 AnchorPoint: "below" 153 -107 basechar 0
@@ -62542,7 +62542,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.elb
-Encoding: 65853 -1 2502
+Encoding: 1114429 -1 2502
 Width: 310
 Flags: MW
 AnchorPoint: "below" 136 -107 basechar 0
@@ -62578,7 +62578,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1A2
-Encoding: 65854 -1 2503
+Encoding: 1114430 -1 2503
 Width: 600
 Flags: MW
 LayerCount: 2
@@ -62614,7 +62614,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1A3
-Encoding: 65855 -1 2504
+Encoding: 1114431 -1 2504
 Width: 894
 Flags: MW
 LayerCount: 2
@@ -62664,7 +62664,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1A5
-Encoding: 65856 -1 2505
+Encoding: 1114432 -1 2505
 Width: 600
 Flags: MW
 LayerCount: 2
@@ -62700,7 +62700,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.elb
-Encoding: 65857 -1 2506
+Encoding: 1114433 -1 2506
 Width: 600
 Flags: MW
 AnchorPoint: "below" 340 -111 basechar 0
@@ -62741,7 +62741,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE199
-Encoding: 65858 -1 2507
+Encoding: 1114434 -1 2507
 Width: 508
 Flags: MW
 AnchorPoint: "ogonek" 447 56 basechar 0
@@ -62754,7 +62754,7 @@ Refer: 278 101 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE198
-Encoding: 65859 -1 2508
+Encoding: 1114435 -1 2508
 Width: 516
 Flags: MW
 AnchorPoint: "ogonek" 496 16 basechar 0
@@ -62768,7 +62768,7 @@ Refer: 274 97 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE19A
-Encoding: 65860 -1 2509
+Encoding: 1114436 -1 2509
 Width: 366
 Flags: MW
 AnchorPoint: "cedilla" 162 10 basechar 0
@@ -62779,7 +62779,7 @@ Refer: 279 102 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE19B
-Encoding: 65861 -1 2510
+Encoding: 1114437 -1 2510
 Width: 582
 Flags: MW
 AnchorPoint: "cedilla" 149 9 basechar 0
@@ -62819,7 +62819,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE19C
-Encoding: 65862 -1 2511
+Encoding: 1114438 -1 2511
 Width: 421
 Flags: MW
 AnchorPoint: "cedilla" 147 7 basechar 0
@@ -62832,7 +62832,7 @@ Refer: 291 114 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE19D
-Encoding: 65863 -1 2512
+Encoding: 1114439 -1 2512
 Width: 318
 Flags: MW
 AnchorPoint: "cedilla" 133 10 basechar 0
@@ -62877,7 +62877,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1BC
-Encoding: 65864 -1 2513
+Encoding: 1114440 -1 2513
 Width: 594
 Flags: MW
 AnchorPoint: "cedilla" 299 4 basechar 0
@@ -62920,7 +62920,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1BA
-Encoding: 65865 -1 2514
+Encoding: 1114441 -1 2514
 Width: 706
 Flags: MW
 AnchorPoint: "below" 404 -110 basechar 0
@@ -62957,7 +62957,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE1BD
-Encoding: 65866 -1 2515
+Encoding: 1114442 -1 2515
 Width: 594
 Flags: MW
 AnchorPoint: "above" 303 805 basechar 0
@@ -63074,7 +63074,7 @@ EndSplineSet
 EndChar
 
 StartChar: aeacute.sc
-Encoding: 65867 -1 2519
+Encoding: 1114443 -1 2519
 Width: 775
 VWidth: 0
 GlyphClass: 2
@@ -63085,7 +63085,7 @@ Refer: 1775 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni01E3.sc
-Encoding: 65868 -1 2520
+Encoding: 1114444 -1 2520
 Width: 775
 VWidth: 0
 GlyphClass: 2
@@ -63096,7 +63096,7 @@ Refer: 1775 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65869 -1 2521
+Encoding: 1114445 -1 2521
 Width: 748
 GlyphClass: 2
 Flags: W
@@ -63149,7 +63149,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle.sc
-Encoding: 65870 -1 2522
+Encoding: 1114446 -1 2522
 Width: 546
 GlyphClass: 2
 Flags: W
@@ -63192,7 +63192,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap
-Encoding: 65871 -1 2523
+Encoding: 1114447 -1 2523
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63214,7 +63214,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.cap
-Encoding: 65872 -1 2524
+Encoding: 1114448 -1 2524
 Width: 555
 VWidth: 1078
 GlyphClass: 2
@@ -63241,7 +63241,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.cap
-Encoding: 65873 -1 2525
+Encoding: 1114449 -1 2525
 Width: 555
 VWidth: 1078
 GlyphClass: 2
@@ -63274,7 +63274,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.cap
-Encoding: 65874 -1 2526
+Encoding: 1114450 -1 2526
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63308,7 +63308,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.cap
-Encoding: 65875 -1 2527
+Encoding: 1114451 -1 2527
 Width: 555
 VWidth: 1078
 GlyphClass: 2
@@ -63343,7 +63343,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.cap
-Encoding: 65876 -1 2528
+Encoding: 1114452 -1 2528
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63379,7 +63379,7 @@ EndSplineSet
 EndChar
 
 StartChar: six.cap
-Encoding: 65877 -1 2529
+Encoding: 1114453 -1 2529
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63407,7 +63407,7 @@ EndSplineSet
 EndChar
 
 StartChar: seven.cap
-Encoding: 65878 -1 2530
+Encoding: 1114454 -1 2530
 Width: 555
 VWidth: 1078
 GlyphClass: 2
@@ -63430,7 +63430,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.cap
-Encoding: 65879 -1 2531
+Encoding: 1114455 -1 2531
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63466,7 +63466,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.cap
-Encoding: 65880 -1 2532
+Encoding: 1114456 -1 2532
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63494,7 +63494,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap.fitted
-Encoding: 65881 -1 2533
+Encoding: 1114457 -1 2533
 Width: 571
 VWidth: 1077
 GlyphClass: 2
@@ -63505,7 +63505,7 @@ Refer: 2523 -1 N 1 0 0 1 9 0 2
 EndChar
 
 StartChar: one.cap.fitted
-Encoding: 65882 -1 2534
+Encoding: 1114458 -1 2534
 Width: 467
 VWidth: 1078
 GlyphClass: 2
@@ -63516,7 +63516,7 @@ Refer: 2524 -1 N 1 0 0 1 -36 0 2
 EndChar
 
 StartChar: two.cap.fitted
-Encoding: 65883 -1 2535
+Encoding: 1114459 -1 2535
 Width: 531
 VWidth: 1078
 GlyphClass: 2
@@ -63527,7 +63527,7 @@ Refer: 2525 -1 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: three.cap.fitted
-Encoding: 65884 -1 2536
+Encoding: 1114460 -1 2536
 Width: 543
 VWidth: 1077
 GlyphClass: 2
@@ -63538,7 +63538,7 @@ Refer: 2526 -1 N 1 0 0 1 3 0 2
 EndChar
 
 StartChar: four.cap.fitted
-Encoding: 65885 -1 2537
+Encoding: 1114461 -1 2537
 Width: 582
 VWidth: 1078
 GlyphClass: 2
@@ -63549,7 +63549,7 @@ Refer: 2527 -1 N 1 0 0 1 11 0 2
 EndChar
 
 StartChar: five.cap.fitted
-Encoding: 65886 -1 2538
+Encoding: 1114462 -1 2538
 Width: 551
 VWidth: 1077
 GlyphClass: 2
@@ -63560,7 +63560,7 @@ Refer: 2528 -1 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: six.cap.fitted
-Encoding: 65887 -1 2539
+Encoding: 1114463 -1 2539
 Width: 553
 VWidth: 1077
 GlyphClass: 2
@@ -63571,7 +63571,7 @@ Refer: 2529 -1 N 1 0 0 1 -3 0 2
 EndChar
 
 StartChar: seven.cap.fitted
-Encoding: 65888 -1 2540
+Encoding: 1114464 -1 2540
 Width: 481
 VWidth: 1078
 GlyphClass: 2
@@ -63582,7 +63582,7 @@ Refer: 2530 -1 N 1 0 0 1 -48 0 2
 EndChar
 
 StartChar: eight.cap.fitted
-Encoding: 65889 -1 2541
+Encoding: 1114465 -1 2541
 Width: 543
 VWidth: 1077
 GlyphClass: 2
@@ -63593,7 +63593,7 @@ Refer: 2531 -1 N 1 0 0 1 -8 0 2
 EndChar
 
 StartChar: nine.cap.fitted
-Encoding: 65890 -1 2542
+Encoding: 1114466 -1 2542
 Width: 567
 VWidth: 1077
 GlyphClass: 2
@@ -63604,7 +63604,7 @@ Refer: 2532 -1 N 1 0 0 1 5 0 2
 EndChar
 
 StartChar: zslash.cap.util
-Encoding: 65891 -1 2543
+Encoding: 1114467 -1 2543
 Width: 555
 VWidth: 1079
 Flags: W
@@ -63620,7 +63620,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.cap
-Encoding: 65892 -1 2544
+Encoding: 1114468 -1 2544
 Width: 555
 VWidth: 1077
 GlyphClass: 2
@@ -63633,7 +63633,7 @@ Refer: 2543 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.slash.cap.fitted
-Encoding: 65893 -1 2545
+Encoding: 1114469 -1 2545
 Width: 571
 VWidth: 1077
 GlyphClass: 2
@@ -63646,7 +63646,7 @@ Refer: 2543 -1 N 1 0 0 1 8 0 2
 EndChar
 
 StartChar: f.short
-Encoding: 65894 -1 2546
+Encoding: 1114470 -1 2546
 Width: 375
 GlyphClass: 2
 Flags: W
@@ -63689,7 +63689,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f.short
-Encoding: 65895 -1 2547
+Encoding: 1114471 -1 2547
 Width: 697
 GlyphClass: 3
 Flags: W
@@ -63755,7 +63755,7 @@ EndSplineSet
 EndChar
 
 StartChar: t_z
-Encoding: 65896 -1 2548
+Encoding: 1114472 -1 2548
 Width: 669
 GlyphClass: 3
 Flags: W
@@ -63808,7 +63808,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.alt
-Encoding: 65897 -1 2549
+Encoding: 1114473 -1 2549
 Width: 642
 GlyphClass: 2
 Flags: W
@@ -63855,7 +63855,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.ss03
-Encoding: 65898 -1 2550
+Encoding: 1114474 -1 2550
 Width: 836
 GlyphClass: 2
 Flags: W
@@ -63866,7 +63866,7 @@ Refer: 1903 115 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni0431.ital
-Encoding: 65899 -1 2551
+Encoding: 1114475 -1 2551
 Width: 505
 GlyphClass: 2
 Flags: W
@@ -63977,7 +63977,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.alt
-Encoding: 65900 -1 2554
+Encoding: 1114476 -1 2554
 Width: 606
 GlyphClass: 2
 Flags: W
@@ -64015,7 +64015,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.scalt
-Encoding: 65901 -1 2555
+Encoding: 1114477 -1 2555
 Width: 552
 GlyphClass: 2
 Flags: W
@@ -64046,7 +64046,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc.u
-Encoding: 65902 -1 2556
+Encoding: 1114478 -1 2556
 Width: 592
 GlyphClass: 2
 Flags: W
@@ -64086,7 +64086,7 @@ Refer: 655 775 N 1 0 0 1 351 14 2
 EndChar
 
 StartChar: uni0249.dotless
-Encoding: 65903 -1 2558
+Encoding: 1114479 -1 2558
 Width: 386
 GlyphClass: 2
 Flags: W
@@ -64123,7 +64123,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0268.dotless
-Encoding: 65904 -1 2559
+Encoding: 1114480 -1 2559
 Width: 347
 GlyphClass: 2
 Flags: W
@@ -64313,7 +64313,7 @@ LayerCount: 2
 EndChar
 
 StartChar: uni0185
-Encoding: 65905 -1 2579
+Encoding: 1114481 -1 2579
 Width: 0
 VWidth: 0
 Flags: W
@@ -64322,7 +64322,7 @@ Colour: 110000
 EndChar
 
 StartChar: uni0196
-Encoding: 65906 -1 2580
+Encoding: 1114482 -1 2580
 Width: 0
 VWidth: 0
 Flags: W
@@ -64331,7 +64331,7 @@ Colour: 110000
 EndChar
 
 StartChar: uni019A
-Encoding: 65907 -1 2581
+Encoding: 1114483 -1 2581
 Width: 0
 VWidth: 0
 Flags: W
@@ -64340,7 +64340,7 @@ Colour: 110000
 EndChar
 
 StartChar: uni0234
-Encoding: 65908 -1 2582
+Encoding: 1114484 -1 2582
 Width: 0
 VWidth: 0
 Flags: W

--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -138,7 +138,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  51 c d e o q ccedilla eogonek oe uni0188 uni018D ohorn
  70 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent uni022F
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -149,7 +149,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 76 {} 80 {} 0 {} 80 {} 40 {} 0 {} 88 {} 0 {} 0 {} 55 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -20 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -44 {} -24 {} 0 {} -61 {} -44 {} -71 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -70 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} -5 {} -34 {} 37 {} 0 {} 10 {} 10 {} 0 {} -29 {} -29 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 15 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 0 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} 0 {} 0 {} -20 {} -20 {} -20 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} -24 {} -40 {} -10 {} 7 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -100 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} -50 {} -12 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -308 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -17 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 12 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
 GaspTable: 3 8 2 17 1 65535 3 0
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 9
@@ -279,7 +279,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "acute" "'mark' Mark Positioning lookup 5" "above" "'mark' Mark Positioning lookup 4" "top_punkt" "'mark' Mark Positioning lookup 4" "below" "'mark' Mark Positioning lookup 3" "cedilla" "'mark' Mark Positioning lookup 2" "ogonek" "'mark' Mark Positioning lookup 1" "middle" "'mark' Mark Positioning in Hebrew lookup 0"
-BeginChars: 65815 2455
+BeginChars: 1114389 2455
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -9872,7 +9872,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Adieresis.alt
-Encoding: 65536 -1 347
+Encoding: 1114112 -1 347
 Width: 633
 GlyphClass: 2
 Flags: MW
@@ -10408,7 +10408,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Odieresis.alt
-Encoding: 65537 -1 365
+Encoding: 1114113 -1 365
 Width: 691
 GlyphClass: 2
 Flags: MW
@@ -10625,7 +10625,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Udieresis.alt
-Encoding: 65538 -1 371
+Encoding: 1114114 -1 371
 Width: 661
 GlyphClass: 2
 Flags: MW
@@ -33920,7 +33920,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenleft.sc
-Encoding: 65539 -1 1256
+Encoding: 1114115 -1 1256
 Width: 300
 GlyphClass: 2
 Flags: MW
@@ -33939,7 +33939,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: parenright.sc
-Encoding: 65540 -1 1257
+Encoding: 1114116 -1 1257
 Width: 300
 GlyphClass: 2
 Flags: MW
@@ -33958,7 +33958,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketleft.sc
-Encoding: 65541 -1 1258
+Encoding: 1114117 -1 1258
 Width: 361
 GlyphClass: 2
 Flags: MW
@@ -33979,7 +33979,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketright.sc
-Encoding: 65542 -1 1259
+Encoding: 1114118 -1 1259
 Width: 361
 GlyphClass: 2
 Flags: MW
@@ -34000,7 +34000,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceleft.sc
-Encoding: 65543 -1 1260
+Encoding: 1114119 -1 1260
 Width: 278
 GlyphClass: 2
 Flags: MW
@@ -34028,7 +34028,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceright.sc
-Encoding: 65544 -1 1261
+Encoding: 1114120 -1 1261
 Width: 278
 GlyphClass: 2
 Flags: MW
@@ -34056,7 +34056,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: exclamdown.sc
-Encoding: 65545 -1 1262
+Encoding: 1114121 -1 1262
 Width: 228
 GlyphClass: 2
 Flags: MW
@@ -34086,7 +34086,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: questiondown.sc
-Encoding: 65546 -1 1263
+Encoding: 1114122 -1 1263
 Width: 405
 GlyphClass: 2
 Flags: MW
@@ -34124,7 +34124,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotleft.sc
-Encoding: 65547 -1 1264
+Encoding: 1114123 -1 1264
 Width: 536
 GlyphClass: 2
 Flags: MW
@@ -34152,7 +34152,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotright.sc
-Encoding: 65548 -1 1265
+Encoding: 1114124 -1 1265
 Width: 536
 GlyphClass: 2
 Flags: MW
@@ -34180,7 +34180,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglleft.sc
-Encoding: 65549 -1 1266
+Encoding: 1114125 -1 1266
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -34191,7 +34191,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglright.sc
-Encoding: 65550 -1 1267
+Encoding: 1114126 -1 1267
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -34202,7 +34202,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_f
-Encoding: 65551 -1 1268
+Encoding: 1114127 -1 1268
 Width: 583
 GlyphClass: 3
 Flags: MW
@@ -34275,7 +34275,7 @@ LCarets2: 1 284
 EndChar
 
 StartChar: f_i
-Encoding: 65552 -1 1269
+Encoding: 1114128 -1 1269
 Width: 576
 Flags: MW
 AnchorPoint: "below" 108.4 -111 basechar 0
@@ -34335,7 +34335,7 @@ LCarets2: 1 277
 EndChar
 
 StartChar: f_l
-Encoding: 65553 -1 1270
+Encoding: 1114129 -1 1270
 Width: 568
 Flags: MW
 LayerCount: 2
@@ -34377,7 +34377,7 @@ LCarets2: 1 288
 EndChar
 
 StartChar: f_f_i
-Encoding: 65554 -1 1271
+Encoding: 1114130 -1 1271
 Width: 844
 Flags: MW
 LayerCount: 2
@@ -34458,7 +34458,7 @@ LCarets2: 2 266 550
 EndChar
 
 StartChar: f_f_l
-Encoding: 65555 -1 1272
+Encoding: 1114131 -1 1272
 Width: 876
 Flags: MW
 LayerCount: 2
@@ -34525,7 +34525,7 @@ LCarets2: 2 268 539
 EndChar
 
 StartChar: longs_t
-Encoding: 65556 -1 1273
+Encoding: 1114132 -1 1273
 Width: 592
 Flags: MW
 LayerCount: 2
@@ -34585,7 +34585,7 @@ LCarets2: 1 265
 EndChar
 
 StartChar: .notdef
-Encoding: 65557 -1 1274
+Encoding: 1114133 -1 1274
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -37487,7 +37487,7 @@ EndSplineSet
 EndChar
 
 StartChar: Yen.fitted
-Encoding: 65558 -1 1368
+Encoding: 1114134 -1 1368
 Width: 488
 GlyphClass: 2
 Flags: MW
@@ -37591,7 +37591,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE01F
-Encoding: 65559 -1 1372
+Encoding: 1114135 -1 1372
 Width: 271
 Flags: MW
 LayerCount: 2
@@ -37611,7 +37611,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.oldstyle
-Encoding: 65560 -1 1373
+Encoding: 1114136 -1 1373
 Width: 516
 GlyphClass: 2
 Flags: MW
@@ -37632,7 +37632,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.oldstyle
-Encoding: 65561 -1 1374
+Encoding: 1114137 -1 1374
 Width: 323
 GlyphClass: 2
 Flags: MW
@@ -37859,7 +37859,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE001
-Encoding: 65562 -1 1376
+Encoding: 1114138 -1 1376
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -37913,7 +37913,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE002
-Encoding: 65563 -1 1377
+Encoding: 1114139 -1 1377
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -37964,7 +37964,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE003
-Encoding: 65564 -1 1378
+Encoding: 1114140 -1 1378
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -38220,7 +38220,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE004
-Encoding: 65565 -1 1380
+Encoding: 1114141 -1 1380
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -38429,7 +38429,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE005
-Encoding: 65566 -1 1384
+Encoding: 1114142 -1 1384
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -38454,7 +38454,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE006
-Encoding: 65567 -1 1385
+Encoding: 1114143 -1 1385
 Width: 1065
 Flags: MW
 LayerCount: 2
@@ -38473,7 +38473,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE007
-Encoding: 65568 -1 1386
+Encoding: 1114144 -1 1386
 Width: 2082
 Flags: MW
 LayerCount: 2
@@ -38492,7 +38492,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE008
-Encoding: 65569 -1 1387
+Encoding: 1114145 -1 1387
 Width: 6272
 Flags: MW
 LayerCount: 2
@@ -38557,7 +38557,7 @@ EndSplineSet
 EndChar
 
 StartChar: s_t
-Encoding: 65570 -1 1388
+Encoding: 1114146 -1 1388
 Width: 680
 GlyphClass: 3
 Flags: MW
@@ -40316,7 +40316,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.fitted
-Encoding: 65571 -1 1454
+Encoding: 1114147 -1 1454
 Width: 363
 GlyphClass: 2
 Flags: MW
@@ -40327,7 +40327,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.fitted
-Encoding: 65572 -1 1455
+Encoding: 1114148 -1 1455
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -40338,7 +40338,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.fitted
-Encoding: 65573 -1 1456
+Encoding: 1114149 -1 1456
 Width: 434
 GlyphClass: 2
 Flags: MW
@@ -40349,7 +40349,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.fitted
-Encoding: 65574 -1 1457
+Encoding: 1114150 -1 1457
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -40360,7 +40360,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.fitted
-Encoding: 65575 -1 1458
+Encoding: 1114151 -1 1458
 Width: 422
 GlyphClass: 2
 Flags: MW
@@ -40371,7 +40371,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.fitted
-Encoding: 65576 -1 1459
+Encoding: 1114152 -1 1459
 Width: 447
 GlyphClass: 2
 Flags: MW
@@ -40382,7 +40382,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.fitted
-Encoding: 65577 -1 1460
+Encoding: 1114153 -1 1460
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -40392,7 +40392,7 @@ Refer: 2220 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: two.oldstyle
-Encoding: 65578 -1 1461
+Encoding: 1114154 -1 1461
 Width: 441
 GlyphClass: 2
 Flags: MW
@@ -40421,7 +40421,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.oldstyle
-Encoding: 65579 -1 1462
+Encoding: 1114155 -1 1462
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -52789,7 +52789,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_t
-Encoding: 65580 -1 1845
+Encoding: 1114156 -1 1845
 Width: 590
 GlyphClass: 3
 Flags: MW
@@ -52931,7 +52931,7 @@ Colour: ffffff
 EndChar
 
 StartChar: zero.slash.fitted
-Encoding: 65581 -1 1849
+Encoding: 1114157 -1 1849
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -52971,7 +52971,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Q.u
-Encoding: 65582 -1 1850
+Encoding: 1114158 -1 1850
 Width: 698
 GlyphClass: 2
 LigCaretCntFixed: 1
@@ -53003,7 +53003,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: T_h
-Encoding: 65583 -1 1851
+Encoding: 1114159 -1 1851
 Width: 980
 Flags: MW
 LayerCount: 2
@@ -53060,7 +53060,7 @@ LCarets2: 1 472
 EndChar
 
 StartChar: zero.fitted
-Encoding: 65584 -1 1852
+Encoding: 1114160 -1 1852
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53083,7 +53083,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.fitted
-Encoding: 65585 -1 1854
+Encoding: 1114161 -1 1854
 Width: 396
 GlyphClass: 2
 Flags: MW
@@ -53094,7 +53094,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.fitted
-Encoding: 65586 -1 1855
+Encoding: 1114162 -1 1855
 Width: 438
 GlyphClass: 2
 Flags: MW
@@ -53105,7 +53105,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Euro.fitted
-Encoding: 65587 -1 1856
+Encoding: 1114163 -1 1856
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -53147,7 +53147,7 @@ EndSplineSet
 EndChar
 
 StartChar: k.sc
-Encoding: 65588 -1 1857
+Encoding: 1114164 -1 1857
 Width: 513
 GlyphClass: 2
 Flags: MW
@@ -53185,7 +53185,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.sc
-Encoding: 65589 -1 1858
+Encoding: 1114165 -1 1858
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -53218,7 +53218,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.sc
-Encoding: 65590 -1 1859
+Encoding: 1114166 -1 1859
 Width: 493
 GlyphClass: 2
 Flags: MW
@@ -53255,7 +53255,7 @@ EndSplineSet
 EndChar
 
 StartChar: c.sc
-Encoding: 65591 -1 1860
+Encoding: 1114167 -1 1860
 Width: 504
 GlyphClass: 2
 Flags: MW
@@ -53279,7 +53279,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.sc
-Encoding: 65592 -1 1861
+Encoding: 1114168 -1 1861
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -53308,7 +53308,7 @@ EndSplineSet
 EndChar
 
 StartChar: e.sc
-Encoding: 65593 -1 1862
+Encoding: 1114169 -1 1862
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -53351,7 +53351,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.sc
-Encoding: 65594 -1 1863
+Encoding: 1114170 -1 1863
 Width: 438
 GlyphClass: 2
 Flags: MW
@@ -53389,7 +53389,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.sc
-Encoding: 65595 -1 1864
+Encoding: 1114171 -1 1864
 Width: 550
 GlyphClass: 2
 Flags: MW
@@ -53421,7 +53421,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.sc
-Encoding: 65596 -1 1865
+Encoding: 1114172 -1 1865
 Width: 563
 GlyphClass: 2
 Flags: MW
@@ -53465,7 +53465,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.sc
-Encoding: 65597 -1 1866
+Encoding: 1114173 -1 1866
 Width: 252
 GlyphClass: 2
 Flags: MW
@@ -53491,7 +53491,7 @@ EndSplineSet
 EndChar
 
 StartChar: j.sc
-Encoding: 65598 -1 1867
+Encoding: 1114174 -1 1867
 Width: 259
 GlyphClass: 2
 Flags: MW
@@ -53519,7 +53519,7 @@ EndSplineSet
 EndChar
 
 StartChar: l.sc
-Encoding: 65599 -1 1868
+Encoding: 1114175 -1 1868
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -53550,7 +53550,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.sc
-Encoding: 65600 -1 1869
+Encoding: 1114176 -1 1869
 Width: 670
 GlyphClass: 2
 Flags: MW
@@ -53581,7 +53581,7 @@ EndSplineSet
 EndChar
 
 StartChar: n.sc
-Encoding: 65601 -1 1870
+Encoding: 1114177 -1 1870
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -53619,7 +53619,7 @@ EndSplineSet
 EndChar
 
 StartChar: o.sc
-Encoding: 65602 -1 1871
+Encoding: 1114178 -1 1871
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -53640,7 +53640,7 @@ EndSplineSet
 EndChar
 
 StartChar: p.sc
-Encoding: 65603 -1 1872
+Encoding: 1114179 -1 1872
 Width: 435
 GlyphClass: 2
 Flags: MW
@@ -53673,7 +53673,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc
-Encoding: 65604 -1 1873
+Encoding: 1114180 -1 1873
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -53700,7 +53700,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: r.sc
-Encoding: 65605 -1 1874
+Encoding: 1114181 -1 1874
 Width: 461
 GlyphClass: 2
 Flags: MW
@@ -53740,7 +53740,7 @@ EndSplineSet
 EndChar
 
 StartChar: s.sc
-Encoding: 65606 -1 1875
+Encoding: 1114182 -1 1875
 Width: 391
 GlyphClass: 2
 Flags: MW
@@ -53770,7 +53770,7 @@ EndSplineSet
 EndChar
 
 StartChar: t.sc
-Encoding: 65607 -1 1876
+Encoding: 1114183 -1 1876
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -53801,7 +53801,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.sc
-Encoding: 65608 -1 1877
+Encoding: 1114184 -1 1877
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -53833,7 +53833,7 @@ EndSplineSet
 EndChar
 
 StartChar: v.sc
-Encoding: 65609 -1 1878
+Encoding: 1114185 -1 1878
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -53859,7 +53859,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.sc
-Encoding: 65610 -1 1879
+Encoding: 1114186 -1 1879
 Width: 793
 GlyphClass: 2
 Flags: MW
@@ -53895,7 +53895,7 @@ EndSplineSet
 EndChar
 
 StartChar: x.sc
-Encoding: 65611 -1 1880
+Encoding: 1114187 -1 1880
 Width: 488
 GlyphClass: 2
 Flags: MW
@@ -53927,7 +53927,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.sc
-Encoding: 65612 -1 1881
+Encoding: 1114188 -1 1881
 Width: 447
 GlyphClass: 2
 Flags: MW
@@ -53955,7 +53955,7 @@ EndSplineSet
 EndChar
 
 StartChar: z.sc
-Encoding: 65613 -1 1882
+Encoding: 1114189 -1 1882
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -53993,7 +53993,7 @@ EndSplineSet
 EndChar
 
 StartChar: agrave.sc
-Encoding: 65614 -1 1883
+Encoding: 1114190 -1 1883
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -54015,7 +54015,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aacute.sc
-Encoding: 65615 -1 1884
+Encoding: 1114191 -1 1884
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -54027,7 +54027,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: acircumflex.sc
-Encoding: 65616 -1 1885
+Encoding: 1114192 -1 1885
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -54039,7 +54039,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: atilde.sc
-Encoding: 65617 -1 1886
+Encoding: 1114193 -1 1886
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -54051,7 +54051,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: adieresis.sc
-Encoding: 65618 -1 1887
+Encoding: 1114194 -1 1887
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -54063,7 +54063,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aring.sc
-Encoding: 65619 -1 1888
+Encoding: 1114195 -1 1888
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -54075,7 +54075,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ae.sc
-Encoding: 65620 -1 1889
+Encoding: 1114196 -1 1889
 Width: 719
 GlyphClass: 2
 Flags: MW
@@ -54129,7 +54129,7 @@ EndSplineSet
 EndChar
 
 StartChar: ccedilla.sc
-Encoding: 65621 -1 1890
+Encoding: 1114197 -1 1890
 Width: 504
 GlyphClass: 2
 Flags: MW
@@ -54166,7 +54166,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: egrave.sc
-Encoding: 65622 -1 1891
+Encoding: 1114198 -1 1891
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -54188,7 +54188,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eacute.sc
-Encoding: 65623 -1 1892
+Encoding: 1114199 -1 1892
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -54200,7 +54200,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ecircumflex.sc
-Encoding: 65624 -1 1893
+Encoding: 1114200 -1 1893
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -54212,7 +54212,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: edieresis.sc
-Encoding: 65625 -1 1894
+Encoding: 1114201 -1 1894
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -54224,7 +54224,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: igrave.sc
-Encoding: 65626 -1 1895
+Encoding: 1114202 -1 1895
 Width: 252
 GlyphClass: 2
 Flags: MW
@@ -54246,7 +54246,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: iacute.sc
-Encoding: 65627 -1 1896
+Encoding: 1114203 -1 1896
 Width: 252
 GlyphClass: 2
 Flags: MW
@@ -54258,7 +54258,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: icircumflex.sc
-Encoding: 65628 -1 1897
+Encoding: 1114204 -1 1897
 Width: 252
 GlyphClass: 2
 Flags: MW
@@ -54270,7 +54270,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: idieresis.sc
-Encoding: 65629 -1 1898
+Encoding: 1114205 -1 1898
 Width: 252
 GlyphClass: 2
 Flags: MW
@@ -54282,7 +54282,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eth.sc
-Encoding: 65630 -1 1899
+Encoding: 1114206 -1 1899
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -54320,7 +54320,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ntilde.sc
-Encoding: 65631 -1 1900
+Encoding: 1114207 -1 1900
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -54332,7 +54332,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ograve.sc
-Encoding: 65632 -1 1901
+Encoding: 1114208 -1 1901
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -54344,7 +54344,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: oacute.sc
-Encoding: 65633 -1 1902
+Encoding: 1114209 -1 1902
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -54356,7 +54356,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ocircumflex.sc
-Encoding: 65634 -1 1903
+Encoding: 1114210 -1 1903
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -54377,7 +54377,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: otilde.sc
-Encoding: 65635 -1 1904
+Encoding: 1114211 -1 1904
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -54389,7 +54389,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: odieresis.sc
-Encoding: 65636 -1 1905
+Encoding: 1114212 -1 1905
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -54401,7 +54401,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: oe.sc
-Encoding: 65637 -1 1906
+Encoding: 1114213 -1 1906
 Width: 725
 GlyphClass: 2
 Flags: MW
@@ -54448,7 +54448,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslash.sc
-Encoding: 65638 -1 1907
+Encoding: 1114214 -1 1907
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -54483,7 +54483,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ugrave.sc
-Encoding: 65639 -1 1908
+Encoding: 1114215 -1 1908
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -54495,7 +54495,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uacute.sc
-Encoding: 65640 -1 1909
+Encoding: 1114216 -1 1909
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -54507,7 +54507,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ucircumflex.sc
-Encoding: 65641 -1 1910
+Encoding: 1114217 -1 1910
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -54519,7 +54519,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: udieresis.sc
-Encoding: 65642 -1 1911
+Encoding: 1114218 -1 1911
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -54531,7 +54531,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: yacute.sc
-Encoding: 65643 -1 1912
+Encoding: 1114219 -1 1912
 Width: 447
 GlyphClass: 2
 Flags: MW
@@ -54553,7 +54553,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: thorn.sc
-Encoding: 65644 -1 1913
+Encoding: 1114220 -1 1913
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -54590,7 +54590,7 @@ EndSplineSet
 EndChar
 
 StartChar: ydieresis.sc
-Encoding: 65645 -1 1914
+Encoding: 1114221 -1 1914
 Width: 447
 GlyphClass: 2
 Flags: MW
@@ -54602,7 +54602,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ij.sc
-Encoding: 65646 -1 1915
+Encoding: 1114222 -1 1915
 Width: 503
 GlyphClass: 2
 Flags: MW
@@ -54614,7 +54614,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: germandbls.scalt
-Encoding: 65647 -1 1916
+Encoding: 1114223 -1 1916
 Width: 769
 GlyphClass: 2
 Flags: MW
@@ -54626,7 +54626,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: hyphen.sc
-Encoding: 65648 -1 1917
+Encoding: 1114224 -1 1917
 Width: 333
 GlyphClass: 2
 Flags: MW
@@ -54645,7 +54645,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ampersand.alt
-Encoding: 65649 -1 1918
+Encoding: 1114225 -1 1918
 Width: 722
 GlyphClass: 2
 Flags: MW
@@ -57499,7 +57499,7 @@ Colour: ffff
 EndChar
 
 StartChar: ae.alt
-Encoding: 65650 -1 1982
+Encoding: 1114226 -1 1982
 Width: 698
 Flags: MW
 LayerCount: 2
@@ -57542,7 +57542,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_s
-Encoding: 65651 -1 1983
+Encoding: 1114227 -1 1983
 Width: 589
 Flags: MW
 LayerCount: 2
@@ -65196,7 +65196,7 @@ EndSplineSet
 EndChar
 
 StartChar: abreve.sc
-Encoding: 65652 -1 2191
+Encoding: 1114228 -1 2191
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -65208,7 +65208,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aogonek.sc
-Encoding: 65653 -1 2192
+Encoding: 1114229 -1 2192
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -65244,7 +65244,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: cacute.sc
-Encoding: 65654 -1 2193
+Encoding: 1114230 -1 2193
 Width: 504
 GlyphClass: 2
 Flags: MW
@@ -65256,7 +65256,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ccaron.sc
-Encoding: 65655 -1 2194
+Encoding: 1114231 -1 2194
 Width: 504
 GlyphClass: 2
 Flags: MW
@@ -65277,7 +65277,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: dcaron.sc
-Encoding: 65656 -1 2195
+Encoding: 1114232 -1 2195
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -65298,7 +65298,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eogonek.sc
-Encoding: 65657 -1 2196
+Encoding: 1114233 -1 2196
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -65349,7 +65349,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ecaron.sc
-Encoding: 65658 -1 2197
+Encoding: 1114234 -1 2197
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -65361,7 +65361,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: gbreve.sc
-Encoding: 65659 -1 2198
+Encoding: 1114235 -1 2198
 Width: 550
 GlyphClass: 2
 Flags: MW
@@ -65373,7 +65373,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lacute.sc
-Encoding: 65660 -1 2199
+Encoding: 1114236 -1 2199
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -65395,7 +65395,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lslash.sc
-Encoding: 65661 -1 2200
+Encoding: 1114237 -1 2200
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -65434,7 +65434,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: nacute.sc
-Encoding: 65662 -1 2201
+Encoding: 1114238 -1 2201
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -65446,7 +65446,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ncaron.sc
-Encoding: 65663 -1 2202
+Encoding: 1114239 -1 2202
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -65458,7 +65458,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eng.sc
-Encoding: 65664 -1 2203
+Encoding: 1114240 -1 2203
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -65501,7 +65501,7 @@ EndSplineSet
 EndChar
 
 StartChar: ohungarumlaut.sc
-Encoding: 65665 -1 2204
+Encoding: 1114241 -1 2204
 Width: 570
 GlyphClass: 2
 Flags: MW
@@ -65532,7 +65532,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: racute.sc
-Encoding: 65666 -1 2205
+Encoding: 1114242 -1 2205
 Width: 461
 GlyphClass: 2
 Flags: MW
@@ -65554,7 +65554,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: rcaron.sc
-Encoding: 65667 -1 2206
+Encoding: 1114243 -1 2206
 Width: 461
 GlyphClass: 2
 Flags: MW
@@ -65566,7 +65566,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: sacute.sc
-Encoding: 65668 -1 2207
+Encoding: 1114244 -1 2207
 Width: 391
 GlyphClass: 2
 Flags: MW
@@ -65588,7 +65588,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: scedilla.sc
-Encoding: 65669 -1 2208
+Encoding: 1114245 -1 2208
 Width: 391
 GlyphClass: 2
 Flags: MW
@@ -65632,7 +65632,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: scaron.sc
-Encoding: 65670 -1 2209
+Encoding: 1114246 -1 2209
 Width: 391
 GlyphClass: 2
 Flags: MW
@@ -65653,7 +65653,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uni0163.sc
-Encoding: 65671 -1 2210
+Encoding: 1114247 -1 2210
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -65699,7 +65699,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: tbar.sc
-Encoding: 65672 -1 2211
+Encoding: 1114248 -1 2211
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -65739,7 +65739,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: uring.sc
-Encoding: 65673 -1 2212
+Encoding: 1114249 -1 2212
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -65751,7 +65751,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uhungarumlaut.sc
-Encoding: 65674 -1 2213
+Encoding: 1114250 -1 2213
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -65782,7 +65782,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zacute.sc
-Encoding: 65675 -1 2214
+Encoding: 1114251 -1 2214
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -65794,7 +65794,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zdotaccent.sc
-Encoding: 65676 -1 2215
+Encoding: 1114252 -1 2215
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -65812,7 +65812,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zcaron.sc
-Encoding: 65677 -1 2216
+Encoding: 1114253 -1 2216
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -65833,7 +65833,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lcaron.sc
-Encoding: 65678 -1 2217
+Encoding: 1114254 -1 2217
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -65854,7 +65854,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: dcroat.sc
-Encoding: 65679 -1 2218
+Encoding: 1114255 -1 2218
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -65865,7 +65865,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: tcaron.sc
-Encoding: 65680 -1 2219
+Encoding: 1114256 -1 2219
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -66647,7 +66647,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.superior
-Encoding: 65681 -1 2242
+Encoding: 1114257 -1 2242
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -66850,7 +66850,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: zero.slash
-Encoding: 65682 -1 2248
+Encoding: 1114258 -1 2248
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -66891,7 +66891,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.sc
-Encoding: 65683 -1 2249
+Encoding: 1114259 -1 2249
 Width: 542
 GlyphClass: 2
 Flags: MW
@@ -66932,7 +66932,7 @@ EndSplineSet
 EndChar
 
 StartChar: t_z.bad
-Encoding: 65684 -1 2250
+Encoding: 1114260 -1 2250
 Width: 532
 Flags: MW
 AnchorPoint: "above" 482.3 646 basechar 0
@@ -66978,7 +66978,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.scalt
-Encoding: 65685 -1 2251
+Encoding: 1114261 -1 2251
 Width: 484
 GlyphClass: 2
 Flags: MW
@@ -67020,7 +67020,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE100
-Encoding: 65686 -1 2253
+Encoding: 1114262 -1 2253
 Width: 633
 Flags: MW
 LayerCount: 2
@@ -67040,7 +67040,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.alt
-Encoding: 65687 -1 2254
+Encoding: 1114263 -1 2254
 Width: 558
 GlyphClass: 2
 Flags: MW
@@ -67085,7 +67085,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.ss03
-Encoding: 65688 -1 2255
+Encoding: 1114264 -1 2255
 Width: 689
 GlyphClass: 2
 Flags: MW
@@ -67136,7 +67136,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.oldstyle
-Encoding: 65689 -1 2256
+Encoding: 1114265 -1 2256
 Width: 460
 GlyphClass: 2
 Flags: MW
@@ -67172,7 +67172,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.oldstyle
-Encoding: 65690 -1 2257
+Encoding: 1114266 -1 2257
 Width: 406
 GlyphClass: 2
 Flags: MW
@@ -67183,7 +67183,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.oldstyle
-Encoding: 65691 -1 2258
+Encoding: 1114267 -1 2258
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -67215,7 +67215,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.oldstyle
-Encoding: 65692 -1 2259
+Encoding: 1114268 -1 2259
 Width: 419
 GlyphClass: 2
 Flags: MW
@@ -67226,7 +67226,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.oldstyle
-Encoding: 65693 -1 2260
+Encoding: 1114269 -1 2260
 Width: 448
 Flags: MW
 LayerCount: 2
@@ -67268,7 +67268,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.oldstyle
-Encoding: 65694 -1 2261
+Encoding: 1114270 -1 2261
 Width: 448
 GlyphClass: 2
 Flags: MW
@@ -67279,7 +67279,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0E8
-Encoding: 65695 -1 2262
+Encoding: 1114271 -1 2262
 Width: 575
 Flags: MW
 LayerCount: 2
@@ -67327,7 +67327,7 @@ EndSplineSet
 EndChar
 
 StartChar: W.alt
-Encoding: 65696 -1 2263
+Encoding: 1114272 -1 2263
 Width: 893
 Flags: MW
 LayerCount: 2
@@ -67388,7 +67388,7 @@ EndSplineSet
 EndChar
 
 StartChar: V.alt
-Encoding: 65697 -1 2264
+Encoding: 1114273 -1 2264
 Width: 604
 Flags: MW
 LayerCount: 2
@@ -67433,7 +67433,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F9
-Encoding: 65700 -1 2265
+Encoding: 1114274 -1 2265
 Width: 623
 Flags: MW
 LayerCount: 2
@@ -67465,7 +67465,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0FB
-Encoding: 65701 -1 2266
+Encoding: 1114275 -1 2266
 Width: 640
 Flags: MW
 LayerCount: 2
@@ -67477,7 +67477,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t_t
-Encoding: 65702 -1 2267
+Encoding: 1114276 -1 2267
 Width: 594
 GlyphClass: 3
 Flags: MW
@@ -67534,7 +67534,7 @@ LCarets2: 1 306
 EndChar
 
 StartChar: c_t
-Encoding: 65703 -1 2268
+Encoding: 1114277 -1 2268
 Width: 715
 GlyphClass: 3
 Flags: MW
@@ -67584,7 +67584,7 @@ LCarets2: 1 407
 EndChar
 
 StartChar: h.alt
-Encoding: 65704 -1 2269
+Encoding: 1114278 -1 2269
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -67617,7 +67617,7 @@ EndSplineSet
 EndChar
 
 StartChar: t_z
-Encoding: 65705 -1 2270
+Encoding: 1114279 -1 2270
 Width: 526
 GlyphClass: 3
 Flags: MW
@@ -67723,7 +67723,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.taboldstyle
-Encoding: 65706 -1 2273
+Encoding: 1114280 -1 2273
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67744,7 +67744,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.taboldstyle
-Encoding: 65707 -1 2274
+Encoding: 1114281 -1 2274
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67755,7 +67755,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.taboldstyle
-Encoding: 65708 -1 2275
+Encoding: 1114282 -1 2275
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67766,7 +67766,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.taboldstyle
-Encoding: 65709 -1 2276
+Encoding: 1114283 -1 2276
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67777,7 +67777,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.taboldstyle
-Encoding: 65710 -1 2277
+Encoding: 1114284 -1 2277
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67788,7 +67788,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.taboldstyle
-Encoding: 65711 -1 2278
+Encoding: 1114285 -1 2278
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67799,7 +67799,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.taboldstyle
-Encoding: 65712 -1 2279
+Encoding: 1114286 -1 2279
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67810,7 +67810,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.taboldstyle
-Encoding: 65713 -1 2280
+Encoding: 1114287 -1 2280
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67821,7 +67821,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.taboldstyle
-Encoding: 65714 -1 2281
+Encoding: 1114288 -1 2281
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67832,7 +67832,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.taboldstyle
-Encoding: 65715 -1 2282
+Encoding: 1114289 -1 2282
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -67885,7 +67885,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE104
-Encoding: 65716 -1 2284
+Encoding: 1114290 -1 2284
 Width: 611
 Flags: MW
 LayerCount: 2
@@ -67982,7 +67982,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE105
-Encoding: 65717 -1 2285
+Encoding: 1114291 -1 2285
 Width: 835
 Flags: MW
 LayerCount: 2
@@ -68123,7 +68123,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE106
-Encoding: 65718 -1 2286
+Encoding: 1114292 -1 2286
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -68215,7 +68215,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE107
-Encoding: 65719 -1 2287
+Encoding: 1114293 -1 2287
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -68296,7 +68296,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni1E9E.alt
-Encoding: 65720 -1 2288
+Encoding: 1114294 -1 2288
 Width: 947
 GlyphClass: 2
 Flags: MW
@@ -68308,7 +68308,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE00B
-Encoding: 65721 -1 2289
+Encoding: 1114295 -1 2289
 Width: 407
 Flags: MW
 LayerCount: 2
@@ -68607,7 +68607,7 @@ EndSplineSet
 EndChar
 
 StartChar: hyphen.cap
-Encoding: 65722 -1 2296
+Encoding: 1114296 -1 2296
 Width: 333
 GlyphClass: 2
 Flags: MW
@@ -68642,7 +68642,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE101
-Encoding: 65723 -1 2298
+Encoding: 1114297 -1 2298
 Width: 759
 Flags: MW
 LayerCount: 2
@@ -68662,7 +68662,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.inferior
-Encoding: 65724 -1 2299
+Encoding: 1114298 -1 2299
 Width: 297
 GlyphClass: 2
 Flags: MW
@@ -68697,7 +68697,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: c.inferior
-Encoding: 65725 -1 2300
+Encoding: 1114299 -1 2300
 Width: 262
 GlyphClass: 2
 Flags: MW
@@ -68725,7 +68725,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: d.inferior
-Encoding: 65726 -1 2301
+Encoding: 1114300 -1 2301
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -68764,7 +68764,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f.inferior
-Encoding: 65727 -1 2302
+Encoding: 1114301 -1 2302
 Width: 253
 GlyphClass: 2
 Flags: MW
@@ -68809,7 +68809,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: g.inferior
-Encoding: 65728 -1 2303
+Encoding: 1114302 -1 2303
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -68859,7 +68859,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: h.inferior
-Encoding: 65729 -1 2304
+Encoding: 1114303 -1 2304
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -68906,7 +68906,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: i.inferior
-Encoding: 65730 -1 2305
+Encoding: 1114304 -1 2305
 Width: 194
 GlyphClass: 2
 Flags: MW
@@ -68941,7 +68941,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: j.inferior
-Encoding: 65731 -1 2306
+Encoding: 1114305 -1 2306
 Width: 207
 GlyphClass: 2
 Flags: MW
@@ -68973,7 +68973,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: k.inferior
-Encoding: 65732 -1 2307
+Encoding: 1114306 -1 2307
 Width: 318
 GlyphClass: 2
 Flags: MW
@@ -69033,7 +69033,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: l.inferior
-Encoding: 65733 -1 2308
+Encoding: 1114307 -1 2308
 Width: 161
 GlyphClass: 2
 Flags: MW
@@ -69065,7 +69065,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: m.inferior
-Encoding: 65734 -1 2309
+Encoding: 1114308 -1 2309
 Width: 485
 GlyphClass: 2
 Flags: MW
@@ -69131,7 +69131,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: n.inferior
-Encoding: 65735 -1 2310
+Encoding: 1114309 -1 2310
 Width: 329
 GlyphClass: 2
 Flags: MW
@@ -69182,7 +69182,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: p.inferior
-Encoding: 65736 -1 2311
+Encoding: 1114310 -1 2311
 Width: 305
 GlyphClass: 2
 Flags: MW
@@ -69225,7 +69225,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: q.inferior
-Encoding: 65737 -1 2312
+Encoding: 1114311 -1 2312
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -69263,7 +69263,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: r.inferior
-Encoding: 65738 -1 2313
+Encoding: 1114312 -1 2313
 Width: 246
 GlyphClass: 2
 Flags: MW
@@ -69302,7 +69302,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: s.inferior
-Encoding: 65739 -1 2314
+Encoding: 1114313 -1 2314
 Width: 248
 GlyphClass: 2
 Flags: MW
@@ -69333,7 +69333,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t.inferior
-Encoding: 65740 -1 2315
+Encoding: 1114314 -1 2315
 Width: 206
 GlyphClass: 2
 Flags: MW
@@ -69366,7 +69366,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: u.inferior
-Encoding: 65741 -1 2316
+Encoding: 1114315 -1 2316
 Width: 319
 GlyphClass: 2
 Flags: MW
@@ -69408,7 +69408,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: v.inferior
-Encoding: 65742 -1 2317
+Encoding: 1114316 -1 2317
 Width: 314
 GlyphClass: 2
 Flags: MW
@@ -69450,7 +69450,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: w.inferior
-Encoding: 65743 -1 2318
+Encoding: 1114317 -1 2318
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -69511,7 +69511,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: y.inferior
-Encoding: 65744 -1 2319
+Encoding: 1114318 -1 2319
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -69559,7 +69559,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: z.inferior
-Encoding: 65745 -1 2320
+Encoding: 1114319 -1 2320
 Width: 274
 GlyphClass: 2
 Flags: MW
@@ -69622,7 +69622,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.alt
-Encoding: 65746 -1 2322
+Encoding: 1114320 -1 2322
 Width: 696
 Flags: MW
 AnchorPoint: "below" 301.4 -111 basechar 0
@@ -69674,7 +69674,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F2
-Encoding: 65747 -1 2323
+Encoding: 1114321 -1 2323
 Width: 890
 Flags: MW
 AnchorPoint: "top_punkt" 582.5 722 basechar 0
@@ -69731,7 +69731,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE06B
-Encoding: 65748 -1 2324
+Encoding: 1114322 -1 2324
 Width: 516
 Flags: MW
 LayerCount: 2
@@ -70917,7 +70917,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0EE
-Encoding: 65749 -1 2348
+Encoding: 1114323 -1 2348
 Width: 550
 Flags: MW
 LayerCount: 2
@@ -70950,7 +70950,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0EF
-Encoding: 65750 -1 2349
+Encoding: 1114324 -1 2349
 Width: 550
 Flags: MW
 LayerCount: 2
@@ -70985,7 +70985,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F3
-Encoding: 65751 -1 2350
+Encoding: 1114325 -1 2350
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -71013,7 +71013,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F4
-Encoding: 65752 -1 2351
+Encoding: 1114326 -1 2351
 Width: 494
 Flags: MW
 LayerCount: 2
@@ -71152,7 +71152,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE128
-Encoding: 65753 -1 2357
+Encoding: 1114327 -1 2357
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -71172,7 +71172,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE129
-Encoding: 65754 -1 2358
+Encoding: 1114328 -1 2358
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -71196,7 +71196,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE12A
-Encoding: 65755 -1 2359
+Encoding: 1114329 -1 2359
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -71591,7 +71591,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni021B.sc
-Encoding: 65756 -1 2369
+Encoding: 1114330 -1 2369
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -71612,7 +71612,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uni0219.sc
-Encoding: 65757 -1 2370
+Encoding: 1114331 -1 2370
 Width: 391
 GlyphClass: 2
 Flags: MW
@@ -71633,7 +71633,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: idotaccent.sc
-Encoding: 65758 -1 2371
+Encoding: 1114332 -1 2371
 Width: 252
 GlyphClass: 2
 Flags: MW
@@ -71645,7 +71645,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0F5
-Encoding: 65759 -1 2372
+Encoding: 1114333 -1 2372
 Width: 550
 Flags: MW
 LayerCount: 2
@@ -71679,7 +71679,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE130
-Encoding: 65760 -1 2373
+Encoding: 1114334 -1 2373
 Width: 166
 Flags: MW
 LayerCount: 2
@@ -71723,7 +71723,7 @@ EndSplineSet
 EndChar
 
 StartChar: ampersand.sc
-Encoding: 65761 -1 2375
+Encoding: 1114335 -1 2375
 Width: 605
 Flags: MW
 LayerCount: 2
@@ -71759,7 +71759,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F0
-Encoding: 65762 -1 2376
+Encoding: 1114336 -1 2376
 Width: 696
 Flags: MW
 AnchorPoint: "below" 301.4 -111 basechar 0
@@ -71811,7 +71811,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.alt
-Encoding: 65763 -1 2377
+Encoding: 1114337 -1 2377
 Width: 521
 GlyphClass: 2
 Flags: MW
@@ -72064,7 +72064,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0CB
-Encoding: 65764 -1 2386
+Encoding: 1114338 -1 2386
 Width: 503
 Flags: MW
 AnchorPoint: "below" 247.2 49 basechar 0
@@ -72123,7 +72123,7 @@ EndSplineSet
 EndChar
 
 StartChar: grave.cap
-Encoding: 65765 -1 2388
+Encoding: 1114339 -1 2388
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72142,7 +72142,7 @@ EndSplineSet
 EndChar
 
 StartChar: acute.cap
-Encoding: 65766 -1 2389
+Encoding: 1114340 -1 2389
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72153,7 +72153,7 @@ Refer: 1682 857 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: circumflex.cap
-Encoding: 65767 -1 2390
+Encoding: 1114341 -1 2390
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72164,7 +72164,7 @@ Refer: 1681 858 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: caron.cap
-Encoding: 65768 -1 2391
+Encoding: 1114342 -1 2391
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72175,7 +72175,7 @@ Refer: 1734 859 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breve.cap
-Encoding: 65769 -1 2392
+Encoding: 1114343 -1 2392
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72186,7 +72186,7 @@ Refer: 1735 860 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: hungarumlaut.cap
-Encoding: 65770 -1 2393
+Encoding: 1114344 -1 2393
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72197,7 +72197,7 @@ Refer: 1736 861 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni030F.cap
-Encoding: 65771 -1 2394
+Encoding: 1114345 -1 2394
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72208,7 +72208,7 @@ Refer: 1737 862 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breveinvertedcmb.cap
-Encoding: 65772 -1 2395
+Encoding: 1114346 -1 2395
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72219,7 +72219,7 @@ Refer: 1738 863 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breve.cyrcap
-Encoding: 65773 -1 2396
+Encoding: 1114347 -1 2396
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72230,7 +72230,7 @@ Refer: 1846 864 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breve.cyr
-Encoding: 65774 -1 2397
+Encoding: 1114348 -1 2397
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72240,7 +72240,7 @@ Refer: 1847 865 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: dieresis.cap
-Encoding: 65775 -1 2398
+Encoding: 1114349 -1 2398
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72251,7 +72251,7 @@ Refer: 1848 866 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: hookabovecomb.cap
-Encoding: 65776 -1 2399
+Encoding: 1114350 -1 2399
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -72261,7 +72261,7 @@ Refer: 2190 867 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: dotaccent.cap
-Encoding: 65777 -1 2400
+Encoding: 1114351 -1 2400
 Width: 291
 GlyphClass: 4
 Flags: MW
@@ -72477,7 +72477,7 @@ Refer: 2165 9002 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: f.short
-Encoding: 65778 -1 2411
+Encoding: 1114352 -1 2411
 Width: 318
 GlyphClass: 2
 Flags: MW
@@ -72489,7 +72489,7 @@ Refer: 286 102 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: f_f.short
-Encoding: 65779 -1 2412
+Encoding: 1114353 -1 2412
 Width: 583
 GlyphClass: 3
 Flags: MW
@@ -72569,7 +72569,7 @@ EndSplineSet
 EndChar
 
 StartChar: aeacute.sc
-Encoding: 65780 -1 2414
+Encoding: 1114354 -1 2414
 Width: 719
 VWidth: 0
 GlyphClass: 2
@@ -72580,7 +72580,7 @@ Refer: 1889 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni01E3.sc
-Encoding: 65781 -1 2415
+Encoding: 1114355 -1 2415
 Width: 719
 VWidth: 0
 GlyphClass: 2
@@ -72591,7 +72591,7 @@ Refer: 1889 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65782 -1 2416
+Encoding: 1114356 -1 2416
 Width: 695
 GlyphClass: 2
 Flags: MW
@@ -72639,7 +72639,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle.sc
-Encoding: 65783 -1 2417
+Encoding: 1114357 -1 2417
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -72683,7 +72683,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap
-Encoding: 65784 -1 2418
+Encoding: 1114358 -1 2418
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72712,7 +72712,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.cap
-Encoding: 65785 -1 2419
+Encoding: 1114359 -1 2419
 Width: 479
 VWidth: 1078
 GlyphClass: 2
@@ -72739,7 +72739,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.cap
-Encoding: 65786 -1 2420
+Encoding: 1114360 -1 2420
 Width: 479
 VWidth: 1078
 GlyphClass: 2
@@ -72773,7 +72773,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.cap
-Encoding: 65787 -1 2421
+Encoding: 1114361 -1 2421
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72813,7 +72813,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.cap
-Encoding: 65788 -1 2422
+Encoding: 1114362 -1 2422
 Width: 479
 VWidth: 1079
 GlyphClass: 2
@@ -72850,7 +72850,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.cap
-Encoding: 65789 -1 2423
+Encoding: 1114363 -1 2423
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72885,7 +72885,7 @@ EndSplineSet
 EndChar
 
 StartChar: six.cap
-Encoding: 65790 -1 2424
+Encoding: 1114364 -1 2424
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72917,7 +72917,7 @@ EndSplineSet
 EndChar
 
 StartChar: seven.cap
-Encoding: 65791 -1 2425
+Encoding: 1114365 -1 2425
 Width: 479
 VWidth: 1078
 GlyphClass: 2
@@ -72940,7 +72940,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.cap
-Encoding: 65792 -1 2426
+Encoding: 1114366 -1 2426
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72984,7 +72984,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.cap
-Encoding: 65793 -1 2427
+Encoding: 1114367 -1 2427
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -73016,7 +73016,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap.fitted
-Encoding: 65794 -1 2428
+Encoding: 1114368 -1 2428
 Width: 500
 VWidth: 1077
 GlyphClass: 2
@@ -73027,7 +73027,7 @@ Refer: 2418 -1 N 1 0 0 1 17 0 2
 EndChar
 
 StartChar: one.cap.fitted
-Encoding: 65795 -1 2429
+Encoding: 1114369 -1 2429
 Width: 389
 VWidth: 1078
 GlyphClass: 2
@@ -73038,7 +73038,7 @@ Refer: 2419 -1 N 1 0 0 1 -14 0 2
 EndChar
 
 StartChar: two.cap.fitted
-Encoding: 65796 -1 2430
+Encoding: 1114370 -1 2430
 Width: 462
 VWidth: 1078
 GlyphClass: 2
@@ -73049,7 +73049,7 @@ Refer: 2420 -1 N 1 0 0 1 -12 0 2
 EndChar
 
 StartChar: three.cap.fitted
-Encoding: 65797 -1 2431
+Encoding: 1114371 -1 2431
 Width: 467
 VWidth: 1077
 GlyphClass: 2
@@ -73060,7 +73060,7 @@ Refer: 2421 -1 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: four.cap.fitted
-Encoding: 65798 -1 2432
+Encoding: 1114372 -1 2432
 Width: 484
 VWidth: 1079
 GlyphClass: 2
@@ -73071,7 +73071,7 @@ Refer: 2422 -1 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: five.cap.fitted
-Encoding: 65799 -1 2433
+Encoding: 1114373 -1 2433
 Width: 455
 VWidth: 1077
 GlyphClass: 2
@@ -73082,7 +73082,7 @@ Refer: 2423 -1 N 1 0 0 1 -12 0 2
 EndChar
 
 StartChar: six.cap.fitted
-Encoding: 65800 -1 2434
+Encoding: 1114374 -1 2434
 Width: 482
 VWidth: 1077
 GlyphClass: 2
@@ -73093,7 +73093,7 @@ Refer: 2424 -1 N 1 0 0 1 4 0 2
 EndChar
 
 StartChar: seven.cap.fitted
-Encoding: 65801 -1 2435
+Encoding: 1114375 -1 2435
 Width: 425
 VWidth: 1078
 GlyphClass: 2
@@ -73104,7 +73104,7 @@ Refer: 2425 -1 N 1 0 0 1 -15 0 2
 EndChar
 
 StartChar: eight.cap.fitted
-Encoding: 65802 -1 2436
+Encoding: 1114376 -1 2436
 Width: 478
 VWidth: 1077
 GlyphClass: 2
@@ -73115,7 +73115,7 @@ Refer: 2426 -1 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: nine.cap.fitted
-Encoding: 65803 -1 2437
+Encoding: 1114377 -1 2437
 Width: 472
 VWidth: 1077
 GlyphClass: 2
@@ -73126,7 +73126,7 @@ Refer: 2427 -1 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: zslash.cap.util
-Encoding: 65804 -1 2438
+Encoding: 1114378 -1 2438
 Width: 479
 VWidth: 1079
 Flags: W
@@ -73142,7 +73142,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.cap
-Encoding: 65805 -1 2439
+Encoding: 1114379 -1 2439
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -73155,7 +73155,7 @@ Refer: 2438 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.slash.cap.fitted
-Encoding: 65806 -1 2440
+Encoding: 1114380 -1 2440
 Width: 500
 VWidth: 1077
 GlyphClass: 2
@@ -73208,7 +73208,7 @@ Refer: 2239 7504 N -1 0 0 -1 657.219 1001 2
 EndChar
 
 StartChar: uni0431.ital
-Encoding: 65807 -1 2445
+Encoding: 1114381 -1 2445
 Width: 468
 GlyphClass: 2
 Flags: W
@@ -73239,7 +73239,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0434.ital
-Encoding: 65808 -1 2446
+Encoding: 1114382 -1 2446
 Width: 506
 GlyphClass: 2
 Flags: W
@@ -73280,7 +73280,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0442.ital
-Encoding: 65809 -1 2447
+Encoding: 1114383 -1 2447
 Width: 807
 GlyphClass: 2
 Flags: W
@@ -73299,7 +73299,7 @@ Refer: 96 1096 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni043F.ital
-Encoding: 65810 -1 2448
+Encoding: 1114384 -1 2448
 Width: 561
 GlyphClass: 2
 Flags: W
@@ -73310,7 +73310,7 @@ Refer: 791 1087 N -1 0 0 -1 656 429 2
 EndChar
 
 StartChar: uni0433.ital
-Encoding: 65811 -1 2449
+Encoding: 1114385 -1 2449
 Width: 268
 GlyphClass: 2
 Flags: W
@@ -73329,7 +73329,7 @@ Refer: 636 618 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: q.sc.u
-Encoding: 65812 -1 2450
+Encoding: 1114386 -1 2450
 Width: 570
 GlyphClass: 2
 LigCaretCntFixed: 1
@@ -73356,7 +73356,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0249.dotless
-Encoding: 65814 -1 2451
+Encoding: 1114387 -1 2451
 Width: 310
 GlyphClass: 2
 Flags: W
@@ -73393,7 +73393,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0268.dotless
-Encoding: 65813 -1 2452
+Encoding: 1114388 -1 2452
 Width: 347
 GlyphClass: 2
 Flags: W

--- a/sources/LibertinusSans-Regular.sfd
+++ b/sources/LibertinusSans-Regular.sfd
@@ -138,7 +138,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  51 c d e o q ccedilla eogonek oe uni0188 uni018D ohorn
  70 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent uni022F
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSans-Regular.sfd
+++ b/sources/LibertinusSans-Regular.sfd
@@ -149,7 +149,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 76 {} 80 {} 0 {} 80 {} 40 {} 0 {} 88 {} 0 {} 0 {} 55 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -20 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -44 {} -24 {} 0 {} -61 {} -44 {} -71 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -80 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} -5 {} -34 {} 37 {} 0 {} 10 {} 10 {} 0 {} -29 {} -29 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 15 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 0 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} 0 {} 0 {} -20 {} -20 {} -20 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} -24 {} -40 {} -10 {} 7 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -65 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} 0 {} -12 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -308 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -17 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 12 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
 GaspTable: 3 8 2 17 1 65535 3 0
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 9
@@ -275,7 +275,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "komb_OR" "'mark' komb OR" "above" "'mark' Above" "top_punkt" "'mark' Above" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle"
-BeginChars: 65828 2429
+BeginChars: 1114402 2429
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -7852,7 +7852,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Adieresis.alt
-Encoding: 65536 -1 344
+Encoding: 1114112 -1 344
 Width: 629
 GlyphClass: 2
 Flags: MW
@@ -8232,7 +8232,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Odieresis.alt
-Encoding: 65537 -1 362
+Encoding: 1114113 -1 362
 Width: 741
 GlyphClass: 2
 Flags: MW
@@ -8357,7 +8357,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Udieresis.alt
-Encoding: 65538 -1 368
+Encoding: 1114114 -1 368
 Width: 692
 GlyphClass: 2
 Flags: MW
@@ -25437,7 +25437,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenleft.sc
-Encoding: 65539 -1 1239
+Encoding: 1114115 -1 1239
 Width: 300
 GlyphClass: 2
 Flags: MW
@@ -25456,7 +25456,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: parenright.sc
-Encoding: 65540 -1 1240
+Encoding: 1114116 -1 1240
 Width: 300
 GlyphClass: 2
 Flags: MW
@@ -25475,7 +25475,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketleft.sc
-Encoding: 65541 -1 1241
+Encoding: 1114117 -1 1241
 Width: 361
 GlyphClass: 2
 Flags: MW
@@ -25496,7 +25496,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketright.sc
-Encoding: 65542 -1 1242
+Encoding: 1114118 -1 1242
 Width: 361
 GlyphClass: 2
 Flags: MW
@@ -25517,7 +25517,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceleft.sc
-Encoding: 65543 -1 1243
+Encoding: 1114119 -1 1243
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -25546,7 +25546,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceright.sc
-Encoding: 65544 -1 1244
+Encoding: 1114120 -1 1244
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -25575,7 +25575,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: exclamdown.sc
-Encoding: 65545 -1 1245
+Encoding: 1114121 -1 1245
 Width: 228
 GlyphClass: 2
 Flags: MW
@@ -25605,7 +25605,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: questiondown.sc
-Encoding: 65546 -1 1246
+Encoding: 1114122 -1 1246
 Width: 405
 GlyphClass: 2
 Flags: MW
@@ -25643,7 +25643,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotleft.sc
-Encoding: 65547 -1 1247
+Encoding: 1114123 -1 1247
 Width: 543
 GlyphClass: 2
 Flags: MW
@@ -25654,7 +25654,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotright.sc
-Encoding: 65548 -1 1248
+Encoding: 1114124 -1 1248
 Width: 543
 GlyphClass: 2
 Flags: MW
@@ -25665,7 +25665,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglleft.sc
-Encoding: 65549 -1 1249
+Encoding: 1114125 -1 1249
 Width: 363
 GlyphClass: 2
 Flags: MW
@@ -25676,7 +25676,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglright.sc
-Encoding: 65550 -1 1250
+Encoding: 1114126 -1 1250
 Width: 363
 GlyphClass: 2
 Flags: MW
@@ -25687,7 +25687,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_f
-Encoding: 65551 -1 1251
+Encoding: 1114127 -1 1251
 Width: 592
 GlyphClass: 3
 Flags: MW
@@ -25751,7 +25751,7 @@ LCarets2: 1 284
 EndChar
 
 StartChar: f_i
-Encoding: 65552 -1 1252
+Encoding: 1114128 -1 1252
 Width: 568
 Flags: MW
 AnchorPoint: "below" 132 -111 basechar 0
@@ -25763,7 +25763,7 @@ LCarets2: 1 293
 EndChar
 
 StartChar: f_l
-Encoding: 65553 -1 1253
+Encoding: 1114129 -1 1253
 Width: 568
 Flags: MW
 LayerCount: 2
@@ -25774,7 +25774,7 @@ LCarets2: 1 288
 EndChar
 
 StartChar: f_f_i
-Encoding: 65554 -1 1254
+Encoding: 1114130 -1 1254
 Width: 844
 Flags: MW
 LayerCount: 2
@@ -25785,7 +25785,7 @@ LCarets2: 2 266 550
 EndChar
 
 StartChar: f_f_l
-Encoding: 65555 -1 1255
+Encoding: 1114131 -1 1255
 Width: 876
 Flags: MW
 LayerCount: 2
@@ -25796,7 +25796,7 @@ LCarets2: 2 268 539
 EndChar
 
 StartChar: longs_t
-Encoding: 65556 -1 1256
+Encoding: 1114132 -1 1256
 Width: 592
 Flags: MW
 LayerCount: 2
@@ -25807,7 +25807,7 @@ LCarets2: 1 265
 EndChar
 
 StartChar: .notdef
-Encoding: 65557 -1 1257
+Encoding: 1114133 -1 1257
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -28629,7 +28629,7 @@ EndSplineSet
 EndChar
 
 StartChar: Yen.fitted
-Encoding: 65558 -1 1351
+Encoding: 1114134 -1 1351
 Width: 509
 GlyphClass: 2
 Flags: MW
@@ -28723,7 +28723,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE01F
-Encoding: 65559 -1 1355
+Encoding: 1114135 -1 1355
 Width: 271
 Flags: MW
 LayerCount: 2
@@ -28743,7 +28743,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.oldstyle
-Encoding: 65560 -1 1356
+Encoding: 1114136 -1 1356
 Width: 526
 GlyphClass: 2
 Flags: MW
@@ -28764,7 +28764,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.oldstyle
-Encoding: 65561 -1 1357
+Encoding: 1114137 -1 1357
 Width: 334
 GlyphClass: 2
 Flags: MW
@@ -28991,7 +28991,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE001
-Encoding: 65562 -1 1359
+Encoding: 1114138 -1 1359
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -29045,7 +29045,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE002
-Encoding: 65563 -1 1360
+Encoding: 1114139 -1 1360
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -29096,7 +29096,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE003
-Encoding: 65564 -1 1361
+Encoding: 1114140 -1 1361
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -29352,7 +29352,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE004
-Encoding: 65565 -1 1363
+Encoding: 1114141 -1 1363
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -29561,7 +29561,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE005
-Encoding: 65566 -1 1367
+Encoding: 1114142 -1 1367
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -29586,7 +29586,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE006
-Encoding: 65567 -1 1368
+Encoding: 1114143 -1 1368
 Width: 1065
 Flags: MW
 LayerCount: 2
@@ -29605,7 +29605,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE007
-Encoding: 65568 -1 1369
+Encoding: 1114144 -1 1369
 Width: 2082
 Flags: MW
 LayerCount: 2
@@ -29624,7 +29624,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE008
-Encoding: 65569 -1 1370
+Encoding: 1114145 -1 1370
 Width: 6272
 Flags: MW
 LayerCount: 2
@@ -29689,7 +29689,7 @@ EndSplineSet
 EndChar
 
 StartChar: s_t
-Encoding: 65570 -1 1371
+Encoding: 1114146 -1 1371
 Width: 707
 GlyphClass: 3
 Flags: MW
@@ -31371,7 +31371,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.fitted
-Encoding: 65571 -1 1437
+Encoding: 1114147 -1 1437
 Width: 330
 GlyphClass: 2
 Flags: MW
@@ -31382,7 +31382,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.fitted
-Encoding: 65572 -1 1438
+Encoding: 1114148 -1 1438
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -31393,7 +31393,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.fitted
-Encoding: 65573 -1 1439
+Encoding: 1114149 -1 1439
 Width: 461
 GlyphClass: 2
 Flags: MW
@@ -31404,7 +31404,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.fitted
-Encoding: 65574 -1 1440
+Encoding: 1114150 -1 1440
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -31415,7 +31415,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.fitted
-Encoding: 65575 -1 1441
+Encoding: 1114151 -1 1441
 Width: 449
 GlyphClass: 2
 Flags: MW
@@ -31426,7 +31426,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.fitted
-Encoding: 65576 -1 1442
+Encoding: 1114152 -1 1442
 Width: 472
 GlyphClass: 2
 Flags: MW
@@ -31437,7 +31437,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.fitted
-Encoding: 65577 -1 1443
+Encoding: 1114153 -1 1443
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -31447,7 +31447,7 @@ Refer: 2131 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: two.oldstyle
-Encoding: 65578 -1 1444
+Encoding: 1114154 -1 1444
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -31476,7 +31476,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.oldstyle
-Encoding: 65579 -1 1445
+Encoding: 1114155 -1 1445
 Width: 448
 GlyphClass: 2
 Flags: MW
@@ -42076,7 +42076,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_t
-Encoding: 65580 -1 1821
+Encoding: 1114156 -1 1821
 Width: 636
 GlyphClass: 3
 Flags: MW
@@ -42206,7 +42206,7 @@ Colour: ffffff
 EndChar
 
 StartChar: zero.slash.fitted
-Encoding: 65581 -1 1825
+Encoding: 1114157 -1 1825
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -42243,7 +42243,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Q.u
-Encoding: 65582 -1 1826
+Encoding: 1114158 -1 1826
 Width: 708
 GlyphClass: 2
 LigCaretCntFixed: 1
@@ -42271,7 +42271,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: zero.fitted
-Encoding: 65583 -1 1827
+Encoding: 1114159 -1 1827
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -42294,7 +42294,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.fitted
-Encoding: 65584 -1 1829
+Encoding: 1114160 -1 1829
 Width: 407
 GlyphClass: 2
 Flags: MW
@@ -42305,7 +42305,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.fitted
-Encoding: 65585 -1 1830
+Encoding: 1114161 -1 1830
 Width: 464
 GlyphClass: 2
 Flags: MW
@@ -42316,7 +42316,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Euro.fitted
-Encoding: 65586 -1 1831
+Encoding: 1114162 -1 1831
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -42358,7 +42358,7 @@ EndSplineSet
 EndChar
 
 StartChar: k.sc
-Encoding: 65587 -1 1832
+Encoding: 1114163 -1 1832
 Width: 483
 GlyphClass: 2
 Flags: MW
@@ -42400,7 +42400,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.sc
-Encoding: 65588 -1 1833
+Encoding: 1114164 -1 1833
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -42433,7 +42433,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.sc
-Encoding: 65589 -1 1834
+Encoding: 1114165 -1 1834
 Width: 488
 GlyphClass: 2
 Flags: MW
@@ -42476,7 +42476,7 @@ EndSplineSet
 EndChar
 
 StartChar: c.sc
-Encoding: 65590 -1 1835
+Encoding: 1114166 -1 1835
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -42505,7 +42505,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.sc
-Encoding: 65591 -1 1836
+Encoding: 1114167 -1 1836
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -42539,7 +42539,7 @@ EndSplineSet
 EndChar
 
 StartChar: e.sc
-Encoding: 65592 -1 1837
+Encoding: 1114168 -1 1837
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -42587,7 +42587,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.sc
-Encoding: 65593 -1 1838
+Encoding: 1114169 -1 1838
 Width: 438
 GlyphClass: 2
 Flags: MW
@@ -42629,7 +42629,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.sc
-Encoding: 65594 -1 1839
+Encoding: 1114170 -1 1839
 Width: 533
 GlyphClass: 2
 Flags: MW
@@ -42666,7 +42666,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.sc
-Encoding: 65595 -1 1840
+Encoding: 1114171 -1 1840
 Width: 553
 GlyphClass: 2
 Flags: MW
@@ -42714,7 +42714,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.sc
-Encoding: 65596 -1 1841
+Encoding: 1114172 -1 1841
 Width: 250
 GlyphClass: 2
 Flags: MW
@@ -42745,7 +42745,7 @@ EndSplineSet
 EndChar
 
 StartChar: j.sc
-Encoding: 65597 -1 1842
+Encoding: 1114173 -1 1842
 Width: 259
 GlyphClass: 2
 Flags: MW
@@ -42777,7 +42777,7 @@ EndSplineSet
 EndChar
 
 StartChar: l.sc
-Encoding: 65598 -1 1843
+Encoding: 1114174 -1 1843
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -42812,7 +42812,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.sc
-Encoding: 65599 -1 1844
+Encoding: 1114175 -1 1844
 Width: 650
 GlyphClass: 2
 Flags: MW
@@ -42844,7 +42844,7 @@ EndSplineSet
 EndChar
 
 StartChar: n.sc
-Encoding: 65600 -1 1845
+Encoding: 1114176 -1 1845
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -42886,7 +42886,7 @@ EndSplineSet
 EndChar
 
 StartChar: o.sc
-Encoding: 65601 -1 1846
+Encoding: 1114177 -1 1846
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -42912,7 +42912,7 @@ EndSplineSet
 EndChar
 
 StartChar: p.sc
-Encoding: 65602 -1 1847
+Encoding: 1114178 -1 1847
 Width: 455
 GlyphClass: 2
 Flags: MW
@@ -42949,7 +42949,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc
-Encoding: 65603 -1 1848
+Encoding: 1114179 -1 1848
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -42980,7 +42980,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: r.sc
-Encoding: 65604 -1 1849
+Encoding: 1114180 -1 1849
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -43025,7 +43025,7 @@ EndSplineSet
 EndChar
 
 StartChar: s.sc
-Encoding: 65605 -1 1850
+Encoding: 1114181 -1 1850
 Width: 429
 GlyphClass: 2
 Flags: MW
@@ -43058,7 +43058,7 @@ EndSplineSet
 EndChar
 
 StartChar: t.sc
-Encoding: 65606 -1 1851
+Encoding: 1114182 -1 1851
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -43093,7 +43093,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.sc
-Encoding: 65607 -1 1852
+Encoding: 1114183 -1 1852
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -43130,7 +43130,7 @@ EndSplineSet
 EndChar
 
 StartChar: v.sc
-Encoding: 65608 -1 1853
+Encoding: 1114184 -1 1853
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -43157,7 +43157,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.sc
-Encoding: 65609 -1 1854
+Encoding: 1114185 -1 1854
 Width: 793
 GlyphClass: 2
 Flags: MW
@@ -43194,7 +43194,7 @@ EndSplineSet
 EndChar
 
 StartChar: x.sc
-Encoding: 65610 -1 1855
+Encoding: 1114186 -1 1855
 Width: 488
 GlyphClass: 2
 Flags: MW
@@ -43226,7 +43226,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.sc
-Encoding: 65611 -1 1856
+Encoding: 1114187 -1 1856
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -43255,7 +43255,7 @@ EndSplineSet
 EndChar
 
 StartChar: z.sc
-Encoding: 65612 -1 1857
+Encoding: 1114188 -1 1857
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -43293,7 +43293,7 @@ EndSplineSet
 EndChar
 
 StartChar: agrave.sc
-Encoding: 65613 -1 1858
+Encoding: 1114189 -1 1858
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -43305,7 +43305,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aacute.sc
-Encoding: 65614 -1 1859
+Encoding: 1114190 -1 1859
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -43317,7 +43317,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: acircumflex.sc
-Encoding: 65615 -1 1860
+Encoding: 1114191 -1 1860
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -43329,7 +43329,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: atilde.sc
-Encoding: 65616 -1 1861
+Encoding: 1114192 -1 1861
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -43341,7 +43341,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: adieresis.sc
-Encoding: 65617 -1 1862
+Encoding: 1114193 -1 1862
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -43353,7 +43353,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aring.sc
-Encoding: 65618 -1 1863
+Encoding: 1114194 -1 1863
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -43365,7 +43365,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ae.sc
-Encoding: 65619 -1 1864
+Encoding: 1114195 -1 1864
 Width: 719
 GlyphClass: 2
 Flags: MW
@@ -43419,7 +43419,7 @@ EndSplineSet
 EndChar
 
 StartChar: ccedilla.sc
-Encoding: 65620 -1 1865
+Encoding: 1114196 -1 1865
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -43456,7 +43456,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: egrave.sc
-Encoding: 65621 -1 1866
+Encoding: 1114197 -1 1866
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -43468,7 +43468,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eacute.sc
-Encoding: 65622 -1 1867
+Encoding: 1114198 -1 1867
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -43480,7 +43480,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ecircumflex.sc
-Encoding: 65623 -1 1868
+Encoding: 1114199 -1 1868
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -43492,7 +43492,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: edieresis.sc
-Encoding: 65624 -1 1869
+Encoding: 1114200 -1 1869
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -43504,7 +43504,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: igrave.sc
-Encoding: 65625 -1 1870
+Encoding: 1114201 -1 1870
 Width: 250
 GlyphClass: 2
 Flags: MW
@@ -43516,7 +43516,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: iacute.sc
-Encoding: 65626 -1 1871
+Encoding: 1114202 -1 1871
 Width: 250
 GlyphClass: 2
 Flags: MW
@@ -43528,7 +43528,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: icircumflex.sc
-Encoding: 65627 -1 1872
+Encoding: 1114203 -1 1872
 Width: 250
 GlyphClass: 2
 Flags: MW
@@ -43540,7 +43540,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: idieresis.sc
-Encoding: 65628 -1 1873
+Encoding: 1114204 -1 1873
 Width: 250
 GlyphClass: 2
 Flags: MW
@@ -43552,7 +43552,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eth.sc
-Encoding: 65629 -1 1874
+Encoding: 1114205 -1 1874
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -43590,7 +43590,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ntilde.sc
-Encoding: 65630 -1 1875
+Encoding: 1114206 -1 1875
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -43602,7 +43602,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ograve.sc
-Encoding: 65631 -1 1876
+Encoding: 1114207 -1 1876
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -43614,7 +43614,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: oacute.sc
-Encoding: 65632 -1 1877
+Encoding: 1114208 -1 1877
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -43626,7 +43626,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ocircumflex.sc
-Encoding: 65633 -1 1878
+Encoding: 1114209 -1 1878
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -43638,7 +43638,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: otilde.sc
-Encoding: 65634 -1 1879
+Encoding: 1114210 -1 1879
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -43650,7 +43650,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: odieresis.sc
-Encoding: 65635 -1 1880
+Encoding: 1114211 -1 1880
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -43662,7 +43662,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: oe.sc
-Encoding: 65636 -1 1881
+Encoding: 1114212 -1 1881
 Width: 725
 GlyphClass: 2
 Flags: MW
@@ -43709,7 +43709,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslash.sc
-Encoding: 65637 -1 1882
+Encoding: 1114213 -1 1882
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -43744,7 +43744,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ugrave.sc
-Encoding: 65638 -1 1883
+Encoding: 1114214 -1 1883
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -43756,7 +43756,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uacute.sc
-Encoding: 65639 -1 1884
+Encoding: 1114215 -1 1884
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -43768,7 +43768,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ucircumflex.sc
-Encoding: 65640 -1 1885
+Encoding: 1114216 -1 1885
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -43780,7 +43780,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: udieresis.sc
-Encoding: 65641 -1 1886
+Encoding: 1114217 -1 1886
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -43792,7 +43792,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: yacute.sc
-Encoding: 65642 -1 1887
+Encoding: 1114218 -1 1887
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -43804,7 +43804,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: thorn.sc
-Encoding: 65643 -1 1888
+Encoding: 1114219 -1 1888
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -43841,7 +43841,7 @@ EndSplineSet
 EndChar
 
 StartChar: ydieresis.sc
-Encoding: 65644 -1 1889
+Encoding: 1114220 -1 1889
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -43853,7 +43853,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ij.sc
-Encoding: 65645 -1 1890
+Encoding: 1114221 -1 1890
 Width: 503
 GlyphClass: 2
 Flags: MW
@@ -43865,7 +43865,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: germandbls.scalt
-Encoding: 65646 -1 1891
+Encoding: 1114222 -1 1891
 Width: 815
 GlyphClass: 2
 Flags: MW
@@ -43877,7 +43877,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: hyphen.sc
-Encoding: 65647 -1 1892
+Encoding: 1114223 -1 1892
 Width: 333
 GlyphClass: 2
 Flags: MW
@@ -43888,7 +43888,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ampersand.alt
-Encoding: 65648 -1 1893
+Encoding: 1114224 -1 1893
 Width: 722
 GlyphClass: 2
 Flags: MW
@@ -50823,7 +50823,7 @@ EndSplineSet
 EndChar
 
 StartChar: abreve.sc
-Encoding: 65649 -1 2102
+Encoding: 1114225 -1 2102
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -50835,7 +50835,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: aogonek.sc
-Encoding: 65650 -1 2103
+Encoding: 1114226 -1 2103
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -50871,7 +50871,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: cacute.sc
-Encoding: 65651 -1 2104
+Encoding: 1114227 -1 2104
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -50883,7 +50883,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ccaron.sc
-Encoding: 65652 -1 2105
+Encoding: 1114228 -1 2105
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -50895,7 +50895,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: dcaron.sc
-Encoding: 65653 -1 2106
+Encoding: 1114229 -1 2106
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -50907,7 +50907,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eogonek.sc
-Encoding: 65654 -1 2107
+Encoding: 1114230 -1 2107
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -50958,7 +50958,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: ecaron.sc
-Encoding: 65655 -1 2108
+Encoding: 1114231 -1 2108
 Width: 451
 GlyphClass: 2
 Flags: MW
@@ -50970,7 +50970,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: gbreve.sc
-Encoding: 65656 -1 2109
+Encoding: 1114232 -1 2109
 Width: 533
 GlyphClass: 2
 Flags: MW
@@ -50982,7 +50982,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lacute.sc
-Encoding: 65657 -1 2110
+Encoding: 1114233 -1 2110
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -50994,7 +50994,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lslash.sc
-Encoding: 65658 -1 2111
+Encoding: 1114234 -1 2111
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -51033,7 +51033,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: nacute.sc
-Encoding: 65659 -1 2112
+Encoding: 1114235 -1 2112
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -51045,7 +51045,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: ncaron.sc
-Encoding: 65660 -1 2113
+Encoding: 1114236 -1 2113
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -51057,7 +51057,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eng.sc
-Encoding: 65661 -1 2114
+Encoding: 1114237 -1 2114
 Width: 529
 GlyphClass: 2
 Flags: MW
@@ -51098,7 +51098,7 @@ EndSplineSet
 EndChar
 
 StartChar: ohungarumlaut.sc
-Encoding: 65662 -1 2115
+Encoding: 1114238 -1 2115
 Width: 534
 GlyphClass: 2
 Flags: MW
@@ -51110,7 +51110,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: racute.sc
-Encoding: 65663 -1 2116
+Encoding: 1114239 -1 2116
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -51122,7 +51122,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: rcaron.sc
-Encoding: 65664 -1 2117
+Encoding: 1114240 -1 2117
 Width: 486
 GlyphClass: 2
 Flags: MW
@@ -51134,7 +51134,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: sacute.sc
-Encoding: 65665 -1 2118
+Encoding: 1114241 -1 2118
 Width: 429
 GlyphClass: 2
 Flags: MW
@@ -51146,7 +51146,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: scedilla.sc
-Encoding: 65666 -1 2119
+Encoding: 1114242 -1 2119
 Width: 429
 GlyphClass: 2
 Flags: MW
@@ -51188,7 +51188,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: scaron.sc
-Encoding: 65667 -1 2120
+Encoding: 1114243 -1 2120
 Width: 429
 GlyphClass: 2
 Flags: MW
@@ -51200,7 +51200,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uni0163.sc
-Encoding: 65668 -1 2121
+Encoding: 1114244 -1 2121
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -51212,7 +51212,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: tbar.sc
-Encoding: 65669 -1 2122
+Encoding: 1114245 -1 2122
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -51252,7 +51252,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: uring.sc
-Encoding: 65670 -1 2123
+Encoding: 1114246 -1 2123
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -51264,7 +51264,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uhungarumlaut.sc
-Encoding: 65671 -1 2124
+Encoding: 1114247 -1 2124
 Width: 541
 GlyphClass: 2
 Flags: MW
@@ -51276,7 +51276,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zacute.sc
-Encoding: 65672 -1 2125
+Encoding: 1114248 -1 2125
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -51288,7 +51288,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zdotaccent.sc
-Encoding: 65673 -1 2126
+Encoding: 1114249 -1 2126
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -51300,7 +51300,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: zcaron.sc
-Encoding: 65674 -1 2127
+Encoding: 1114250 -1 2127
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -51312,7 +51312,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: lcaron.sc
-Encoding: 65675 -1 2128
+Encoding: 1114251 -1 2128
 Width: 433
 GlyphClass: 2
 Flags: MW
@@ -51324,7 +51324,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: dcroat.sc
-Encoding: 65676 -1 2129
+Encoding: 1114252 -1 2129
 Width: 566
 GlyphClass: 2
 Flags: MW
@@ -51335,7 +51335,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: tcaron.sc
-Encoding: 65677 -1 2130
+Encoding: 1114253 -1 2130
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -51722,7 +51722,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.superior
-Encoding: 65678 -1 2143
+Encoding: 1114254 -1 2143
 Width: 344
 Flags: MW
 LayerCount: 2
@@ -51756,7 +51756,7 @@ EndSplineSet
 EndChar
 
 StartChar: c.superior
-Encoding: 65679 -1 2144
+Encoding: 1114255 -1 2144
 Width: 304
 Flags: MW
 LayerCount: 2
@@ -51784,7 +51784,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.superior
-Encoding: 65680 -1 2145
+Encoding: 1114256 -1 2145
 Width: 348
 Flags: MW
 LayerCount: 2
@@ -51821,7 +51821,7 @@ EndSplineSet
 EndChar
 
 StartChar: e.superior
-Encoding: 65681 -1 2146
+Encoding: 1114257 -1 2146
 Width: 311
 Flags: MW
 LayerCount: 2
@@ -51831,7 +51831,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f.superior
-Encoding: 65682 -1 2147
+Encoding: 1114258 -1 2147
 Width: 218
 Flags: MW
 LayerCount: 2
@@ -51873,7 +51873,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.superior
-Encoding: 65683 -1 2148
+Encoding: 1114259 -1 2148
 Width: 344
 Flags: MW
 LayerCount: 2
@@ -51929,7 +51929,7 @@ EndSplineSet
 EndChar
 
 StartChar: k.superior
-Encoding: 65684 -1 2149
+Encoding: 1114260 -1 2149
 Width: 330
 Flags: MW
 LayerCount: 2
@@ -51965,7 +51965,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.superior
-Encoding: 65685 -1 2150
+Encoding: 1114261 -1 2150
 Width: 566
 Flags: MW
 LayerCount: 2
@@ -52016,7 +52016,7 @@ EndSplineSet
 EndChar
 
 StartChar: o.superior
-Encoding: 65686 -1 2151
+Encoding: 1114262 -1 2151
 Width: 359
 Flags: MW
 LayerCount: 2
@@ -52026,7 +52026,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: p.superior
-Encoding: 65687 -1 2152
+Encoding: 1114263 -1 2152
 Width: 392
 Flags: MW
 LayerCount: 2
@@ -52065,7 +52065,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.superior
-Encoding: 65688 -1 2153
+Encoding: 1114264 -1 2153
 Width: 386
 GlyphClass: 2
 Flags: MW
@@ -52100,7 +52100,7 @@ EndSplineSet
 EndChar
 
 StartChar: t.superior
-Encoding: 65689 -1 2154
+Encoding: 1114265 -1 2154
 Width: 222
 Flags: MW
 LayerCount: 2
@@ -52135,7 +52135,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.superior
-Encoding: 65690 -1 2155
+Encoding: 1114266 -1 2155
 Width: 400
 Flags: MW
 LayerCount: 2
@@ -52144,7 +52144,7 @@ Refer: 2348 7512 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: v.superior
-Encoding: 65691 -1 2156
+Encoding: 1114267 -1 2156
 Width: 331
 Flags: MW
 LayerCount: 2
@@ -52153,7 +52153,7 @@ Refer: 2349 7515 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: z.superior
-Encoding: 65692 -1 2157
+Encoding: 1114268 -1 2157
 Width: 297
 Flags: MW
 LayerCount: 2
@@ -52237,7 +52237,7 @@ Colour: ff80cc
 EndChar
 
 StartChar: zero.slash
-Encoding: 65693 -1 2159
+Encoding: 1114269 -1 2159
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -52273,7 +52273,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.sc
-Encoding: 65694 -1 2160
+Encoding: 1114270 -1 2160
 Width: 542
 GlyphClass: 2
 Flags: MW
@@ -52314,7 +52314,7 @@ EndSplineSet
 EndChar
 
 StartChar: t_z.bad
-Encoding: 65695 -1 2161
+Encoding: 1114271 -1 2161
 Width: 532
 Flags: MW
 AnchorPoint: "above" 345 646 basechar 0
@@ -52360,7 +52360,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.scalt.bad
-Encoding: 65696 -1 2162
+Encoding: 1114272 -1 2162
 Width: 506
 Flags: MW
 LayerCount: 2
@@ -52420,7 +52420,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.superior
-Encoding: 65697 -1 2163
+Encoding: 1114273 -1 2163
 Width: 297
 Flags: MW
 LayerCount: 2
@@ -52430,7 +52430,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE100
-Encoding: 65698 -1 2164
+Encoding: 1114274 -1 2164
 Width: 633
 Flags: MW
 LayerCount: 2
@@ -52450,7 +52450,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.alt
-Encoding: 65699 -1 2165
+Encoding: 1114275 -1 2165
 Width: 558
 GlyphClass: 2
 Flags: MW
@@ -52495,7 +52495,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.oldstyle
-Encoding: 65700 -1 2166
+Encoding: 1114276 -1 2166
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -52531,7 +52531,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.oldstyle
-Encoding: 65701 -1 2167
+Encoding: 1114277 -1 2167
 Width: 425
 GlyphClass: 2
 Flags: MW
@@ -52542,7 +52542,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.oldstyle
-Encoding: 65702 -1 2168
+Encoding: 1114278 -1 2168
 Width: 469
 GlyphClass: 2
 Flags: MW
@@ -52553,7 +52553,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.oldstyle
-Encoding: 65703 -1 2169
+Encoding: 1114279 -1 2169
 Width: 432
 GlyphClass: 2
 Flags: MW
@@ -52564,7 +52564,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.oldstyle
-Encoding: 65704 -1 2170
+Encoding: 1114280 -1 2170
 Width: 465
 Flags: MW
 LayerCount: 2
@@ -52573,7 +52573,7 @@ Refer: 2131 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: nine.oldstyle
-Encoding: 65705 -1 2171
+Encoding: 1114281 -1 2171
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -52584,7 +52584,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0E8
-Encoding: 65706 -1 2172
+Encoding: 1114282 -1 2172
 Width: 575
 Flags: MW
 LayerCount: 2
@@ -52632,7 +52632,7 @@ EndSplineSet
 EndChar
 
 StartChar: W.alt
-Encoding: 65707 -1 2173
+Encoding: 1114283 -1 2173
 Width: 893
 Flags: MW
 LayerCount: 2
@@ -52693,7 +52693,7 @@ EndSplineSet
 EndChar
 
 StartChar: V.alt
-Encoding: 65708 -1 2174
+Encoding: 1114284 -1 2174
 Width: 604
 Flags: MW
 LayerCount: 2
@@ -52738,7 +52738,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F9
-Encoding: 65711 -1 2175
+Encoding: 1114285 -1 2175
 Width: 623
 Flags: MW
 LayerCount: 2
@@ -52750,7 +52750,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0FB
-Encoding: 65712 -1 2176
+Encoding: 1114286 -1 2176
 Width: 640
 Flags: MW
 LayerCount: 2
@@ -52762,7 +52762,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t_t
-Encoding: 65713 -1 2177
+Encoding: 1114287 -1 2177
 Width: 602
 GlyphClass: 3
 Flags: MW
@@ -52815,7 +52815,7 @@ LCarets2: 1 294
 EndChar
 
 StartChar: c_t
-Encoding: 65714 -1 2178
+Encoding: 1114288 -1 2178
 Width: 763
 GlyphClass: 3
 Flags: MW
@@ -52869,7 +52869,7 @@ LCarets2: 1 407
 EndChar
 
 StartChar: h.alt
-Encoding: 65715 -1 2179
+Encoding: 1114289 -1 2179
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -52952,7 +52952,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.taboldstyle
-Encoding: 65716 -1 2182
+Encoding: 1114290 -1 2182
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -52973,7 +52973,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.taboldstyle
-Encoding: 65717 -1 2183
+Encoding: 1114291 -1 2183
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -52984,7 +52984,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.taboldstyle
-Encoding: 65718 -1 2184
+Encoding: 1114292 -1 2184
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -52995,7 +52995,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.taboldstyle
-Encoding: 65719 -1 2185
+Encoding: 1114293 -1 2185
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53006,7 +53006,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.taboldstyle
-Encoding: 65720 -1 2186
+Encoding: 1114294 -1 2186
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53017,7 +53017,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.taboldstyle
-Encoding: 65721 -1 2187
+Encoding: 1114295 -1 2187
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53028,7 +53028,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.taboldstyle
-Encoding: 65722 -1 2188
+Encoding: 1114296 -1 2188
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53039,7 +53039,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.taboldstyle
-Encoding: 65723 -1 2189
+Encoding: 1114297 -1 2189
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53050,7 +53050,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.taboldstyle
-Encoding: 65724 -1 2190
+Encoding: 1114298 -1 2190
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53061,7 +53061,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.taboldstyle
-Encoding: 65725 -1 2191
+Encoding: 1114299 -1 2191
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -53114,7 +53114,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE104
-Encoding: 65726 -1 2193
+Encoding: 1114300 -1 2193
 Width: 611
 Flags: MW
 LayerCount: 2
@@ -53211,7 +53211,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE105
-Encoding: 65727 -1 2194
+Encoding: 1114301 -1 2194
 Width: 835
 Flags: MW
 LayerCount: 2
@@ -53352,7 +53352,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE106
-Encoding: 65728 -1 2195
+Encoding: 1114302 -1 2195
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -53444,7 +53444,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE107
-Encoding: 65729 -1 2196
+Encoding: 1114303 -1 2196
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -53525,7 +53525,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni1E9E.alt
-Encoding: 65730 -1 2197
+Encoding: 1114304 -1 2197
 Width: 947
 GlyphClass: 2
 Flags: MW
@@ -53537,7 +53537,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE00B
-Encoding: 65731 -1 2198
+Encoding: 1114305 -1 2198
 Width: 407
 Flags: MW
 LayerCount: 2
@@ -53836,7 +53836,7 @@ EndSplineSet
 EndChar
 
 StartChar: hyphen.cap
-Encoding: 65732 -1 2205
+Encoding: 1114306 -1 2205
 Width: 333
 GlyphClass: 2
 Flags: MW
@@ -53871,7 +53871,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE101
-Encoding: 65733 -1 2207
+Encoding: 1114307 -1 2207
 Width: 759
 Flags: MW
 LayerCount: 2
@@ -53891,7 +53891,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.inferior
-Encoding: 65734 -1 2208
+Encoding: 1114308 -1 2208
 Width: 344
 GlyphClass: 2
 Flags: MW
@@ -53902,7 +53902,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: c.inferior
-Encoding: 65735 -1 2209
+Encoding: 1114309 -1 2209
 Width: 304
 GlyphClass: 2
 Flags: MW
@@ -53913,7 +53913,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: d.inferior
-Encoding: 65736 -1 2210
+Encoding: 1114310 -1 2210
 Width: 348
 GlyphClass: 2
 Flags: MW
@@ -53924,7 +53924,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f.inferior
-Encoding: 65737 -1 2211
+Encoding: 1114311 -1 2211
 Width: 218
 GlyphClass: 2
 Flags: MW
@@ -53935,7 +53935,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: g.inferior
-Encoding: 65738 -1 2212
+Encoding: 1114312 -1 2212
 Width: 344
 GlyphClass: 2
 Flags: MW
@@ -53946,7 +53946,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: h.inferior
-Encoding: 65739 -1 2213
+Encoding: 1114313 -1 2213
 Width: 335
 GlyphClass: 2
 Flags: MW
@@ -53957,7 +53957,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: i.inferior
-Encoding: 65740 -1 2214
+Encoding: 1114314 -1 2214
 Width: 244
 GlyphClass: 2
 Flags: MW
@@ -53992,7 +53992,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: j.inferior
-Encoding: 65741 -1 2215
+Encoding: 1114315 -1 2215
 Width: 280
 GlyphClass: 2
 Flags: MW
@@ -54003,7 +54003,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: k.inferior
-Encoding: 65742 -1 2216
+Encoding: 1114316 -1 2216
 Width: 318
 GlyphClass: 2
 Flags: MW
@@ -54014,7 +54014,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: l.inferior
-Encoding: 65743 -1 2217
+Encoding: 1114317 -1 2217
 Width: 226
 GlyphClass: 2
 Flags: MW
@@ -54025,7 +54025,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: m.inferior
-Encoding: 65744 -1 2218
+Encoding: 1114318 -1 2218
 Width: 485
 GlyphClass: 2
 Flags: MW
@@ -54036,7 +54036,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: n.inferior
-Encoding: 65745 -1 2219
+Encoding: 1114319 -1 2219
 Width: 319
 GlyphClass: 2
 Flags: MW
@@ -54047,7 +54047,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: p.inferior
-Encoding: 65746 -1 2220
+Encoding: 1114320 -1 2220
 Width: 305
 GlyphClass: 2
 Flags: MW
@@ -54058,7 +54058,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: q.inferior
-Encoding: 65747 -1 2221
+Encoding: 1114321 -1 2221
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -54069,7 +54069,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: r.inferior
-Encoding: 65748 -1 2222
+Encoding: 1114322 -1 2222
 Width: 282
 GlyphClass: 2
 Flags: MW
@@ -54080,7 +54080,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: s.inferior
-Encoding: 65749 -1 2223
+Encoding: 1114323 -1 2223
 Width: 276
 GlyphClass: 2
 Flags: MW
@@ -54091,7 +54091,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t.inferior
-Encoding: 65750 -1 2224
+Encoding: 1114324 -1 2224
 Width: 206
 GlyphClass: 2
 Flags: MW
@@ -54102,7 +54102,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: u.inferior
-Encoding: 65751 -1 2225
+Encoding: 1114325 -1 2225
 Width: 400
 GlyphClass: 2
 Flags: MW
@@ -54113,7 +54113,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: v.inferior
-Encoding: 65752 -1 2226
+Encoding: 1114326 -1 2226
 Width: 314
 GlyphClass: 2
 Flags: MW
@@ -54124,7 +54124,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: w.inferior
-Encoding: 65753 -1 2227
+Encoding: 1114327 -1 2227
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -54135,7 +54135,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: y.inferior
-Encoding: 65754 -1 2228
+Encoding: 1114328 -1 2228
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -54146,7 +54146,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: z.inferior
-Encoding: 65755 -1 2229
+Encoding: 1114329 -1 2229
 Width: 297
 GlyphClass: 2
 Flags: MW
@@ -54186,7 +54186,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.alt
-Encoding: 65756 -1 2231
+Encoding: 1114330 -1 2231
 Width: 696
 Flags: MW
 AnchorPoint: "below" 325 -111 basechar 0
@@ -54238,7 +54238,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F2
-Encoding: 65757 -1 2232
+Encoding: 1114331 -1 2232
 Width: 890
 Flags: MW
 AnchorPoint: "top_punkt" 429 722 basechar 0
@@ -54295,7 +54295,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0EE
-Encoding: 65758 -1 2233
+Encoding: 1114332 -1 2233
 Width: 550
 Flags: MW
 LayerCount: 2
@@ -54328,7 +54328,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0EF
-Encoding: 65759 -1 2234
+Encoding: 1114333 -1 2234
 Width: 550
 Flags: MW
 LayerCount: 2
@@ -54363,7 +54363,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F3
-Encoding: 65760 -1 2235
+Encoding: 1114334 -1 2235
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -54391,7 +54391,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F4
-Encoding: 65761 -1 2236
+Encoding: 1114335 -1 2236
 Width: 494
 Flags: MW
 LayerCount: 2
@@ -54532,7 +54532,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE128
-Encoding: 65762 -1 2242
+Encoding: 1114336 -1 2242
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -54552,7 +54552,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE129
-Encoding: 65763 -1 2243
+Encoding: 1114337 -1 2243
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -54576,7 +54576,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE12A
-Encoding: 65764 -1 2244
+Encoding: 1114338 -1 2244
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -54971,7 +54971,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni021B.sc
-Encoding: 65765 -1 2254
+Encoding: 1114339 -1 2254
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -54983,7 +54983,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uni0219.sc
-Encoding: 65766 -1 2255
+Encoding: 1114340 -1 2255
 Width: 429
 GlyphClass: 2
 Flags: MW
@@ -54995,7 +54995,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: idotaccent.sc
-Encoding: 65767 -1 2256
+Encoding: 1114341 -1 2256
 Width: 250
 GlyphClass: 2
 Flags: MW
@@ -55007,7 +55007,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0F5
-Encoding: 65768 -1 2257
+Encoding: 1114342 -1 2257
 Width: 550
 Flags: MW
 LayerCount: 2
@@ -55041,7 +55041,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE130
-Encoding: 65769 -1 2258
+Encoding: 1114343 -1 2258
 Width: 166
 Flags: MW
 LayerCount: 2
@@ -55085,7 +55085,7 @@ EndSplineSet
 EndChar
 
 StartChar: ampersand.sc
-Encoding: 65770 -1 2260
+Encoding: 1114344 -1 2260
 Width: 605
 Flags: MW
 LayerCount: 2
@@ -55121,7 +55121,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F0
-Encoding: 65771 -1 2261
+Encoding: 1114345 -1 2261
 Width: 696
 Flags: MW
 AnchorPoint: "below" 325 -111 basechar 0
@@ -55173,7 +55173,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.alt
-Encoding: 65772 -1 2262
+Encoding: 1114346 -1 2262
 Width: 521
 GlyphClass: 2
 Flags: MW
@@ -55457,7 +55457,7 @@ EndSplineSet
 EndChar
 
 StartChar: grave.cap
-Encoding: 65773 -1 2272
+Encoding: 1114347 -1 2272
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55476,7 +55476,7 @@ EndSplineSet
 EndChar
 
 StartChar: acute.cap
-Encoding: 65774 -1 2273
+Encoding: 1114348 -1 2273
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55495,7 +55495,7 @@ EndSplineSet
 EndChar
 
 StartChar: circumflex.cap
-Encoding: 65775 -1 2274
+Encoding: 1114349 -1 2274
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55515,7 +55515,7 @@ EndSplineSet
 EndChar
 
 StartChar: caron.cap
-Encoding: 65776 -1 2275
+Encoding: 1114350 -1 2275
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55535,7 +55535,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cap
-Encoding: 65777 -1 2276
+Encoding: 1114351 -1 2276
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55554,7 +55554,7 @@ EndSplineSet
 EndChar
 
 StartChar: hungarumlaut.cap
-Encoding: 65778 -1 2277
+Encoding: 1114352 -1 2277
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55584,7 +55584,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni030F.cap
-Encoding: 65779 -1 2278
+Encoding: 1114353 -1 2278
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55614,7 +55614,7 @@ EndSplineSet
 EndChar
 
 StartChar: breveinvertedcmb.cap
-Encoding: 65780 -1 2279
+Encoding: 1114354 -1 2279
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55633,7 +55633,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyrcap
-Encoding: 65781 -1 2280
+Encoding: 1114355 -1 2280
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55656,7 +55656,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyr
-Encoding: 65782 -1 2281
+Encoding: 1114356 -1 2281
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55680,7 +55680,7 @@ EndSplineSet
 EndChar
 
 StartChar: dieresis.cap
-Encoding: 65783 -1 2282
+Encoding: 1114357 -1 2282
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55702,7 +55702,7 @@ EndSplineSet
 EndChar
 
 StartChar: hookabovecomb.cap
-Encoding: 65784 -1 2283
+Encoding: 1114358 -1 2283
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -55727,7 +55727,7 @@ EndSplineSet
 EndChar
 
 StartChar: dotaccent.cap
-Encoding: 65785 -1 2284
+Encoding: 1114359 -1 2284
 Width: 291
 GlyphClass: 4
 Flags: MW
@@ -57870,7 +57870,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0DA
-Encoding: 65786 -1 2363
+Encoding: 1114360 -1 2363
 Width: 311
 Flags: MW
 LayerCount: 2
@@ -57879,14 +57879,14 @@ Refer: 1712 8340 N 1 0 0 1 0 464 2
 EndChar
 
 StartChar: uniE14C
-Encoding: 65787 -1 2364
+Encoding: 1114361 -1 2364
 Width: 1000
 Flags: MW
 LayerCount: 2
 EndChar
 
 StartChar: uniE162
-Encoding: 65788 -1 2365
+Encoding: 1114362 -1 2365
 Width: 317
 Flags: MW
 LayerCount: 2
@@ -57901,7 +57901,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE163
-Encoding: 65789 -1 2366
+Encoding: 1114363 -1 2366
 Width: 317
 Flags: MW
 LayerCount: 2
@@ -57916,7 +57916,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE164
-Encoding: 65790 -1 2367
+Encoding: 1114364 -1 2367
 Width: 476
 Flags: MW
 LayerCount: 2
@@ -57934,7 +57934,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE165
-Encoding: 65791 -1 2368
+Encoding: 1114365 -1 2368
 Width: 476
 Flags: MW
 LayerCount: 2
@@ -57952,7 +57952,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.short
-Encoding: 65792 -1 2369
+Encoding: 1114366 -1 2369
 Width: 323
 GlyphClass: 2
 Flags: MW
@@ -57996,7 +57996,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f.short
-Encoding: 65793 -1 2370
+Encoding: 1114367 -1 2370
 Width: 607
 GlyphClass: 3
 Flags: MW
@@ -58137,7 +58137,7 @@ EndSplineSet
 EndChar
 
 StartChar: aeacute.sc
-Encoding: 65794 -1 2374
+Encoding: 1114368 -1 2374
 Width: 719
 VWidth: 0
 GlyphClass: 2
@@ -58149,7 +58149,7 @@ Refer: 1864 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni01E3.sc
-Encoding: 65795 -1 2375
+Encoding: 1114369 -1 2375
 Width: 719
 VWidth: 0
 GlyphClass: 2
@@ -58161,7 +58161,7 @@ Refer: 1864 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65796 -1 2376
+Encoding: 1114370 -1 2376
 Width: 695
 GlyphClass: 2
 Flags: W
@@ -58209,7 +58209,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle.sc
-Encoding: 65797 -1 2377
+Encoding: 1114371 -1 2377
 Width: 546
 GlyphClass: 2
 Flags: W
@@ -58281,7 +58281,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap
-Encoding: 65798 -1 2379
+Encoding: 1114372 -1 2379
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58306,7 +58306,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.cap
-Encoding: 65799 -1 2380
+Encoding: 1114373 -1 2380
 Width: 502
 VWidth: 1078
 GlyphClass: 2
@@ -58333,7 +58333,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.cap
-Encoding: 65800 -1 2381
+Encoding: 1114374 -1 2381
 Width: 502
 VWidth: 1078
 GlyphClass: 2
@@ -58367,7 +58367,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.cap
-Encoding: 65801 -1 2382
+Encoding: 1114375 -1 2382
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58404,7 +58404,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.cap
-Encoding: 65802 -1 2383
+Encoding: 1114376 -1 2383
 Width: 502
 VWidth: 1079
 GlyphClass: 2
@@ -58441,7 +58441,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.cap
-Encoding: 65803 -1 2384
+Encoding: 1114377 -1 2384
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58474,7 +58474,7 @@ EndSplineSet
 EndChar
 
 StartChar: six.cap
-Encoding: 65804 -1 2385
+Encoding: 1114378 -1 2385
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58502,7 +58502,7 @@ EndSplineSet
 EndChar
 
 StartChar: seven.cap
-Encoding: 65805 -1 2386
+Encoding: 1114379 -1 2386
 Width: 502
 VWidth: 1078
 GlyphClass: 2
@@ -58525,7 +58525,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.cap
-Encoding: 65806 -1 2387
+Encoding: 1114380 -1 2387
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58561,7 +58561,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.cap
-Encoding: 65807 -1 2388
+Encoding: 1114381 -1 2388
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58589,7 +58589,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap.fitted
-Encoding: 65808 -1 2389
+Encoding: 1114382 -1 2389
 Width: 508
 VWidth: 1077
 GlyphClass: 2
@@ -58600,7 +58600,7 @@ Refer: 2379 -1 N 1 0 0 1 6 0 2
 EndChar
 
 StartChar: one.cap.fitted
-Encoding: 65809 -1 2390
+Encoding: 1114383 -1 2390
 Width: 353
 VWidth: 1078
 GlyphClass: 2
@@ -58611,7 +58611,7 @@ Refer: 2380 -1 N 1 0 0 1 -46 0 2
 EndChar
 
 StartChar: two.cap.fitted
-Encoding: 65810 -1 2391
+Encoding: 1114384 -1 2391
 Width: 475
 VWidth: 1078
 GlyphClass: 2
@@ -58622,7 +58622,7 @@ Refer: 2381 -1 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: three.cap.fitted
-Encoding: 65811 -1 2392
+Encoding: 1114385 -1 2392
 Width: 494
 VWidth: 1077
 GlyphClass: 2
@@ -58633,7 +58633,7 @@ Refer: 2382 -1 N 1 0 0 1 -12 0 2
 EndChar
 
 StartChar: four.cap.fitted
-Encoding: 65812 -1 2393
+Encoding: 1114386 -1 2393
 Width: 509
 VWidth: 1079
 GlyphClass: 2
@@ -58644,7 +58644,7 @@ Refer: 2383 -1 N 1 0 0 1 10 0 2
 EndChar
 
 StartChar: five.cap.fitted
-Encoding: 65813 -1 2394
+Encoding: 1114387 -1 2394
 Width: 480
 VWidth: 1077
 GlyphClass: 2
@@ -58655,7 +58655,7 @@ Refer: 2384 -1 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: six.cap.fitted
-Encoding: 65814 -1 2395
+Encoding: 1114388 -1 2395
 Width: 505
 VWidth: 1077
 GlyphClass: 2
@@ -58666,7 +58666,7 @@ Refer: 2385 -1 N 1 0 0 1 -5 0 2
 EndChar
 
 StartChar: seven.cap.fitted
-Encoding: 65815 -1 2396
+Encoding: 1114389 -1 2396
 Width: 436
 VWidth: 1078
 GlyphClass: 2
@@ -58677,7 +58677,7 @@ Refer: 2386 -1 N 1 0 0 1 -36 0 2
 EndChar
 
 StartChar: eight.cap.fitted
-Encoding: 65816 -1 2397
+Encoding: 1114390 -1 2397
 Width: 499
 VWidth: 1077
 GlyphClass: 2
@@ -58688,7 +58688,7 @@ Refer: 2387 -1 N 1 0 0 1 -1 0 2
 EndChar
 
 StartChar: nine.cap.fitted
-Encoding: 65817 -1 2398
+Encoding: 1114391 -1 2398
 Width: 498
 VWidth: 1077
 GlyphClass: 2
@@ -58699,7 +58699,7 @@ Refer: 2388 -1 N 1 0 0 1 8 0 2
 EndChar
 
 StartChar: zslash.cap.util
-Encoding: 65818 -1 2399
+Encoding: 1114392 -1 2399
 Width: 502
 VWidth: 1079
 Flags: W
@@ -58715,7 +58715,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.cap
-Encoding: 65819 -1 2400
+Encoding: 1114393 -1 2400
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -58728,7 +58728,7 @@ Refer: 2399 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.slash.cap.fitted
-Encoding: 65820 -1 2401
+Encoding: 1114394 -1 2401
 Width: 508
 VWidth: 1077
 GlyphClass: 2
@@ -58741,7 +58741,7 @@ Refer: 2399 -1 N 1 0 0 1 6 0 2
 EndChar
 
 StartChar: t_z
-Encoding: 65821 -1 2402
+Encoding: 1114395 -1 2402
 Width: 561
 GlyphClass: 3
 Flags: W
@@ -58790,7 +58790,7 @@ LCarets2: 1 0
 EndChar
 
 StartChar: germandbls.ss03
-Encoding: 65822 -1 2403
+Encoding: 1114396 -1 2403
 Width: 794
 GlyphClass: 2
 Flags: W
@@ -58801,7 +58801,7 @@ Refer: 1994 115 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni0431.ital
-Encoding: 65823 -1 2404
+Encoding: 1114397 -1 2404
 Width: 505
 GlyphClass: 2
 Flags: W
@@ -58832,7 +58832,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.scalt
-Encoding: 65824 -1 2405
+Encoding: 1114398 -1 2405
 Width: 470
 GlyphClass: 2
 Flags: W
@@ -58863,7 +58863,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc.u
-Encoding: 65825 -1 2406
+Encoding: 1114399 -1 2406
 Width: 534
 GlyphClass: 2
 Flags: W
@@ -58893,7 +58893,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0249.dotless
-Encoding: 65827 -1 2407
+Encoding: 1114400 -1 2407
 Width: 284
 GlyphClass: 2
 Flags: W
@@ -58928,7 +58928,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0268.dotless
-Encoding: 65826 -1 2408
+Encoding: 1114401 -1 2408
 Width: 347
 GlyphClass: 2
 Flags: W

--- a/sources/LibertinusSerif-Bold.sfd
+++ b/sources/LibertinusSerif-Bold.sfd
@@ -138,7 +138,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  59 c d e o q ccedilla eogonek oe uni0188 uni018D ohorn uni01DD
  70 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent uni022F
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -121,7 +121,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  37 c d e o q ccedilla eogonek oe c_k c_h
  62 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -148,7 +148,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  1 u
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 76 {} 80 {} 0 {} 80 {} 40 {} 0 {} 88 {} 0 {} 0 {} 55 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -20 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -44 {} -24 {} 0 {} -61 {} -44 {} -71 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -70 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} -5 {} -34 {} 37 {} 0 {} 10 {} 10 {} 0 {} -29 {} -29 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 15 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 0 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} 0 {} 0 {} -20 {} -20 {} -20 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} -24 {} -40 {} -10 {} 7 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -100 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} -50 {} -12 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -308 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -17 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 12 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 9
@@ -306,7 +306,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 65826 2392
+BeginChars: 1114402 2392
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -8866,7 +8866,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: Adieresis.alt
-Encoding: 65536 -1 349
+Encoding: 1114112 -1 349
 Width: 667
 GlyphClass: 2
 Flags: MW
@@ -9274,7 +9274,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: Odieresis.alt
-Encoding: 65537 -1 367
+Encoding: 1114113 -1 367
 Width: 668
 GlyphClass: 2
 Flags: MW
@@ -9388,7 +9388,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: Udieresis.alt
-Encoding: 65538 -1 373
+Encoding: 1114114 -1 373
 Width: 634
 GlyphClass: 2
 Flags: MW
@@ -33591,7 +33591,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenleft.sc
-Encoding: 65539 -1 1257
+Encoding: 1114115 -1 1257
 Width: 295
 GlyphClass: 2
 Flags: MW
@@ -33609,7 +33609,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenright.sc
-Encoding: 65540 -1 1258
+Encoding: 1114116 -1 1258
 Width: 295
 GlyphClass: 2
 Flags: MW
@@ -33627,7 +33627,7 @@ EndSplineSet
 EndChar
 
 StartChar: bracketleft.sc
-Encoding: 65541 -1 1259
+Encoding: 1114117 -1 1259
 Width: 302
 GlyphClass: 2
 Flags: MW
@@ -33647,7 +33647,7 @@ EndSplineSet
 EndChar
 
 StartChar: bracketright.sc
-Encoding: 65542 -1 1260
+Encoding: 1114118 -1 1260
 Width: 302
 GlyphClass: 2
 Flags: MW
@@ -33667,7 +33667,7 @@ EndSplineSet
 EndChar
 
 StartChar: braceleft.sc
-Encoding: 65543 -1 1261
+Encoding: 1114119 -1 1261
 Width: 273
 GlyphClass: 2
 Flags: MW
@@ -33698,7 +33698,7 @@ EndSplineSet
 EndChar
 
 StartChar: braceright.sc
-Encoding: 65544 -1 1262
+Encoding: 1114120 -1 1262
 Width: 273
 GlyphClass: 2
 Flags: MW
@@ -33729,7 +33729,7 @@ EndSplineSet
 EndChar
 
 StartChar: exclamdown.sc
-Encoding: 65545 -1 1263
+Encoding: 1114121 -1 1263
 Width: 227
 GlyphClass: 2
 Flags: MW
@@ -33754,7 +33754,7 @@ EndSplineSet
 EndChar
 
 StartChar: questiondown.sc
-Encoding: 65546 -1 1264
+Encoding: 1114122 -1 1264
 Width: 405
 GlyphClass: 2
 Flags: MW
@@ -33789,7 +33789,7 @@ EndSplineSet
 EndChar
 
 StartChar: guillemotleft.sc
-Encoding: 65547 -1 1265
+Encoding: 1114123 -1 1265
 Width: 536
 GlyphClass: 2
 Flags: MW
@@ -33816,7 +33816,7 @@ EndSplineSet
 EndChar
 
 StartChar: guillemotright.sc
-Encoding: 65548 -1 1266
+Encoding: 1114124 -1 1266
 Width: 536
 GlyphClass: 2
 Flags: MW
@@ -33843,7 +33843,7 @@ EndSplineSet
 EndChar
 
 StartChar: guilsinglleft.sc
-Encoding: 65549 -1 1267
+Encoding: 1114125 -1 1267
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -33862,7 +33862,7 @@ EndSplineSet
 EndChar
 
 StartChar: guilsinglright.sc
-Encoding: 65550 -1 1268
+Encoding: 1114126 -1 1268
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -33881,7 +33881,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f
-Encoding: 65551 -1 1269
+Encoding: 1114127 -1 1269
 Width: 568
 GlyphClass: 3
 Flags: MW
@@ -33947,7 +33947,7 @@ LCarets2: 1 257
 EndChar
 
 StartChar: f_i
-Encoding: 65552 -1 1270
+Encoding: 1114128 -1 1270
 Width: 564
 GlyphClass: 3
 Flags: MW
@@ -34002,7 +34002,7 @@ LCarets2: 1 280
 EndChar
 
 StartChar: f_l
-Encoding: 65553 -1 1271
+Encoding: 1114129 -1 1271
 Width: 570
 GlyphClass: 3
 Flags: MW
@@ -34056,7 +34056,7 @@ LCarets2: 1 314
 EndChar
 
 StartChar: f_f_i
-Encoding: 65554 -1 1272
+Encoding: 1114130 -1 1272
 Width: 819
 GlyphClass: 3
 Flags: MW
@@ -34136,7 +34136,7 @@ LCarets2: 2 280 538
 EndChar
 
 StartChar: f_f_l
-Encoding: 65555 -1 1273
+Encoding: 1114131 -1 1273
 Width: 830
 GlyphClass: 3
 Flags: MW
@@ -34209,7 +34209,7 @@ LCarets2: 2 283 557
 EndChar
 
 StartChar: longs_t
-Encoding: 65556 -1 1274
+Encoding: 1114132 -1 1274
 Width: 606
 GlyphClass: 3
 Flags: MW
@@ -37728,7 +37728,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.oldstyle
-Encoding: 65557 -1 1369
+Encoding: 1114133 -1 1369
 Width: 516
 GlyphClass: 2
 Flags: MW
@@ -37749,7 +37749,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.oldstyle
-Encoding: 65558 -1 1370
+Encoding: 1114134 -1 1370
 Width: 323
 GlyphClass: 2
 Flags: MW
@@ -37775,7 +37775,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.oldstyle
-Encoding: 65559 -1 1371
+Encoding: 1114135 -1 1371
 Width: 415
 GlyphClass: 2
 Flags: MW
@@ -37816,7 +37816,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.oldstyle
-Encoding: 65560 -1 1374
+Encoding: 1114136 -1 1374
 Width: 447
 GlyphClass: 2
 Flags: MW
@@ -37855,7 +37855,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.oldstyle
-Encoding: 65561 -1 1376
+Encoding: 1114137 -1 1376
 Width: 411
 GlyphClass: 2
 Flags: MW
@@ -37865,7 +37865,7 @@ Refer: 14 53 N 1 0 0 1 -63 -172 2
 EndChar
 
 StartChar: six.oldstyle
-Encoding: 65562 -1 1377
+Encoding: 1114138 -1 1377
 Width: 438
 GlyphClass: 2
 Flags: MW
@@ -37875,7 +37875,7 @@ Refer: 15 54 N 1 0 0 1 -7 0.0201103 2
 EndChar
 
 StartChar: seven.oldstyle
-Encoding: 65563 -1 1378
+Encoding: 1114139 -1 1378
 Width: 407
 GlyphClass: 2
 Flags: MW
@@ -38086,7 +38086,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE001
-Encoding: 65564 -1 1380
+Encoding: 1114140 -1 1380
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -38140,7 +38140,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE002
-Encoding: 65565 -1 1381
+Encoding: 1114141 -1 1381
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -38194,7 +38194,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE003
-Encoding: 65566 -1 1382
+Encoding: 1114142 -1 1382
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -38449,7 +38449,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE004
-Encoding: 65567 -1 1384
+Encoding: 1114143 -1 1384
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -38659,7 +38659,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE005
-Encoding: 65568 -1 1388
+Encoding: 1114144 -1 1388
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -38684,7 +38684,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE006
-Encoding: 65569 -1 1389
+Encoding: 1114145 -1 1389
 Width: 2341
 Flags: MW
 LayerCount: 2
@@ -38713,7 +38713,7 @@ Refer: 257 46 N 1 0 0 1 1061 209 2
 EndChar
 
 StartChar: uniE007
-Encoding: 65570 -1 1390
+Encoding: 1114146 -1 1390
 Width: 4421
 Flags: MW
 LayerCount: 2
@@ -40149,7 +40149,7 @@ EndSplineSet
 EndChar
 
 StartChar: s_t
-Encoding: 65571 -1 1449
+Encoding: 1114147 -1 1449
 Width: 648
 GlyphClass: 3
 Flags: MW
@@ -40206,7 +40206,7 @@ LCarets2: 1 354
 EndChar
 
 StartChar: uniE008
-Encoding: 65572 -1 1450
+Encoding: 1114148 -1 1450
 Width: 6272
 Flags: MW
 LayerCount: 2
@@ -46301,7 +46301,7 @@ LCarets2: 2 0 0
 EndChar
 
 StartChar: zero.fitted
-Encoding: 65573 -1 1607
+Encoding: 1114149 -1 1607
 Width: 471
 GlyphClass: 2
 Flags: MW
@@ -46311,7 +46311,7 @@ Refer: 258 48 N 1 0 0 1 18 0 2
 EndChar
 
 StartChar: one.fitted
-Encoding: 65574 -1 1608
+Encoding: 1114150 -1 1608
 Width: 373
 GlyphClass: 2
 Flags: MW
@@ -46321,7 +46321,7 @@ Refer: 10 49 N 1 0 0 1 -33.8879 0 2
 EndChar
 
 StartChar: two.fitted
-Encoding: 65575 -1 1609
+Encoding: 1114151 -1 1609
 Width: 459
 GlyphClass: 2
 Flags: MW
@@ -46331,7 +46331,7 @@ Refer: 11 50 N 1 0 0 1 11 0 2
 EndChar
 
 StartChar: three.fitted
-Encoding: 65576 -1 1610
+Encoding: 1114152 -1 1610
 Width: 454
 GlyphClass: 2
 Flags: MW
@@ -46341,7 +46341,7 @@ Refer: 12 51 N 1 0 0 1 11 0 2
 EndChar
 
 StartChar: four.fitted
-Encoding: 65577 -1 1611
+Encoding: 1114153 -1 1611
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -46351,7 +46351,7 @@ Refer: 13 52 N 1 0 0 1 3.99935 0 2
 EndChar
 
 StartChar: five.fitted
-Encoding: 65578 -1 1612
+Encoding: 1114154 -1 1612
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -46361,7 +46361,7 @@ Refer: 14 53 N 1 0 0 1 5 0 2
 EndChar
 
 StartChar: six.fitted
-Encoding: 65579 -1 1613
+Encoding: 1114155 -1 1613
 Width: 466
 GlyphClass: 2
 Flags: MW
@@ -46371,7 +46371,7 @@ Refer: 15 54 N 1 0 0 1 15 0 2
 EndChar
 
 StartChar: seven.fitted
-Encoding: 65580 -1 1614
+Encoding: 1114156 -1 1614
 Width: 419
 GlyphClass: 2
 Flags: MW
@@ -46381,7 +46381,7 @@ Refer: 16 55 N 1 0 0 1 -25 0 2
 EndChar
 
 StartChar: eight.fitted
-Encoding: 65581 -1 1615
+Encoding: 1114157 -1 1615
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -46391,7 +46391,7 @@ Refer: 2066 56 N 1 0 0 1 14 0 2
 EndChar
 
 StartChar: nine.fitted
-Encoding: 65582 -1 1616
+Encoding: 1114158 -1 1616
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -46401,7 +46401,7 @@ Refer: 17 57 N 1 0 0 1 11.0006 0 2
 EndChar
 
 StartChar: Euro.fitted
-Encoding: 65583 -1 1617
+Encoding: 1114159 -1 1617
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -46441,7 +46441,7 @@ EndSplineSet
 EndChar
 
 StartChar: Yen.fitted
-Encoding: 65584 -1 1618
+Encoding: 1114160 -1 1618
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -46512,7 +46512,7 @@ EndSplineSet
 EndChar
 
 StartChar: perthousandzero
-Encoding: 65585 -1 1619
+Encoding: 1114161 -1 1619
 Width: 280
 Flags: MW
 LayerCount: 2
@@ -46532,7 +46532,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.oldstyle
-Encoding: 65586 -1 1620
+Encoding: 1114162 -1 1620
 Width: 448
 Flags: MW
 LayerCount: 2
@@ -46541,7 +46541,7 @@ Refer: 2066 56 N 1 0 0 1 -9 0 2
 EndChar
 
 StartChar: nine.oldstyle
-Encoding: 65587 -1 1621
+Encoding: 1114163 -1 1621
 Width: 448
 GlyphClass: 2
 Flags: MW
@@ -51794,7 +51794,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_k
-Encoding: 65588 -1 1757
+Encoding: 1114164 -1 1757
 Width: 797
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -51866,7 +51866,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_t
-Encoding: 65589 -1 1758
+Encoding: 1114165 -1 1758
 Width: 611
 GlyphClass: 3
 Flags: MW
@@ -51923,7 +51923,7 @@ LCarets2: 1 298
 EndChar
 
 StartChar: c_k
-Encoding: 65590 -1 1759
+Encoding: 1114166 -1 1759
 Width: 836
 GlyphClass: 3
 Flags: MW
@@ -51935,7 +51935,7 @@ LCarets2: 1 386
 EndChar
 
 StartChar: c_h
-Encoding: 65591 -1 1760
+Encoding: 1114167 -1 1760
 Width: 863
 GlyphClass: 3
 Flags: MW
@@ -51947,7 +51947,7 @@ LCarets2: 1 387
 EndChar
 
 StartChar: t_t
-Encoding: 65592 -1 1761
+Encoding: 1114168 -1 1761
 Width: 606
 GlyphClass: 3
 Flags: MW
@@ -51998,7 +51998,7 @@ LCarets2: 1 296
 EndChar
 
 StartChar: c_t
-Encoding: 65593 -1 1762
+Encoding: 1114169 -1 1762
 Width: 694
 GlyphClass: 3
 Flags: MW
@@ -52056,7 +52056,7 @@ LCarets2: 1 371
 EndChar
 
 StartChar: ae.alt
-Encoding: 65594 -1 1763
+Encoding: 1114170 -1 1763
 Width: 698
 Flags: MW
 LayerCount: 2
@@ -52099,7 +52099,7 @@ EndSplineSet
 EndChar
 
 StartChar: Q.u
-Encoding: 65595 -1 1764
+Encoding: 1114171 -1 1764
 Width: 668
 GlyphClass: 2
 Flags: MW
@@ -52139,7 +52139,7 @@ EndSplineSet
 EndChar
 
 StartChar: T_h
-Encoding: 65596 -1 1765
+Encoding: 1114172 -1 1765
 Width: 961
 GlyphClass: 3
 Flags: MW
@@ -52197,7 +52197,7 @@ LCarets2: 1 444
 EndChar
 
 StartChar: ampersand.alt
-Encoding: 65597 -1 1766
+Encoding: 1114173 -1 1766
 Width: 710
 GlyphClass: 2
 Flags: MW
@@ -52252,7 +52252,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.sc
-Encoding: 65598 -1 1767
+Encoding: 1114174 -1 1767
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -52303,7 +52303,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.sc
-Encoding: 65599 -1 1768
+Encoding: 1114175 -1 1768
 Width: 482
 GlyphClass: 2
 Flags: MW
@@ -52350,7 +52350,7 @@ EndSplineSet
 EndChar
 
 StartChar: c.sc
-Encoding: 65600 -1 1769
+Encoding: 1114176 -1 1769
 Width: 494
 GlyphClass: 2
 Flags: MW
@@ -52377,7 +52377,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.sc
-Encoding: 65601 -1 1770
+Encoding: 1114177 -1 1770
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -52416,7 +52416,7 @@ EndSplineSet
 EndChar
 
 StartChar: e.sc
-Encoding: 65602 -1 1771
+Encoding: 1114178 -1 1771
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -52473,7 +52473,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.sc
-Encoding: 65603 -1 1772
+Encoding: 1114179 -1 1772
 Width: 437
 GlyphClass: 2
 Flags: MW
@@ -52530,7 +52530,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.sc
-Encoding: 65604 -1 1773
+Encoding: 1114180 -1 1773
 Width: 539
 GlyphClass: 2
 Flags: MW
@@ -52572,7 +52572,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.sc
-Encoding: 65605 -1 1774
+Encoding: 1114181 -1 1774
 Width: 590
 GlyphClass: 2
 Flags: MW
@@ -52644,7 +52644,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.sc
-Encoding: 65606 -1 1775
+Encoding: 1114182 -1 1775
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -52684,7 +52684,7 @@ EndSplineSet
 EndChar
 
 StartChar: j.sc
-Encoding: 65607 -1 1776
+Encoding: 1114183 -1 1776
 Width: 296
 GlyphClass: 2
 Flags: MW
@@ -52721,7 +52721,7 @@ EndSplineSet
 EndChar
 
 StartChar: k.sc
-Encoding: 65608 -1 1777
+Encoding: 1114184 -1 1777
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -52792,7 +52792,7 @@ EndSplineSet
 EndChar
 
 StartChar: l.sc
-Encoding: 65609 -1 1778
+Encoding: 1114185 -1 1778
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -52833,7 +52833,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.sc
-Encoding: 65610 -1 1779
+Encoding: 1114186 -1 1779
 Width: 648
 GlyphClass: 2
 Flags: MW
@@ -52889,7 +52889,7 @@ EndSplineSet
 EndChar
 
 StartChar: n.sc
-Encoding: 65611 -1 1780
+Encoding: 1114187 -1 1780
 Width: 591
 GlyphClass: 2
 Flags: MW
@@ -52944,7 +52944,7 @@ EndSplineSet
 EndChar
 
 StartChar: o.sc
-Encoding: 65612 -1 1781
+Encoding: 1114188 -1 1781
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -52969,7 +52969,7 @@ EndSplineSet
 EndChar
 
 StartChar: p.sc
-Encoding: 65613 -1 1782
+Encoding: 1114189 -1 1782
 Width: 435
 GlyphClass: 2
 Flags: MW
@@ -53013,7 +53013,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc
-Encoding: 65614 -1 1783
+Encoding: 1114190 -1 1783
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -53051,7 +53051,7 @@ EndSplineSet
 EndChar
 
 StartChar: r.sc
-Encoding: 65615 -1 1784
+Encoding: 1114191 -1 1784
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -53104,7 +53104,7 @@ EndSplineSet
 EndChar
 
 StartChar: s.sc
-Encoding: 65616 -1 1785
+Encoding: 1114192 -1 1785
 Width: 383
 GlyphClass: 2
 Flags: MW
@@ -53140,7 +53140,7 @@ EndSplineSet
 EndChar
 
 StartChar: t.sc
-Encoding: 65617 -1 1786
+Encoding: 1114193 -1 1786
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -53183,7 +53183,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.sc
-Encoding: 65618 -1 1787
+Encoding: 1114194 -1 1787
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -53232,7 +53232,7 @@ EndSplineSet
 EndChar
 
 StartChar: v.sc
-Encoding: 65619 -1 1788
+Encoding: 1114195 -1 1788
 Width: 529
 GlyphClass: 2
 Flags: MW
@@ -53274,7 +53274,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.sc
-Encoding: 65620 -1 1789
+Encoding: 1114196 -1 1789
 Width: 768
 GlyphClass: 2
 Flags: MW
@@ -53341,7 +53341,7 @@ EndSplineSet
 EndChar
 
 StartChar: x.sc
-Encoding: 65621 -1 1790
+Encoding: 1114197 -1 1790
 Width: 548
 GlyphClass: 2
 Flags: MW
@@ -53421,7 +53421,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.sc
-Encoding: 65622 -1 1791
+Encoding: 1114198 -1 1791
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -53477,7 +53477,7 @@ EndSplineSet
 EndChar
 
 StartChar: z.sc
-Encoding: 65623 -1 1792
+Encoding: 1114199 -1 1792
 Width: 470
 GlyphClass: 2
 Flags: MW
@@ -53514,7 +53514,7 @@ EndSplineSet
 EndChar
 
 StartChar: hyphen.sc
-Encoding: 65624 -1 1793
+Encoding: 1114200 -1 1793
 Width: 333
 GlyphClass: 2
 Flags: MW
@@ -53534,7 +53534,7 @@ EndSplineSet
 EndChar
 
 StartChar: agrave.sc
-Encoding: 65625 -1 1794
+Encoding: 1114201 -1 1794
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -53545,7 +53545,7 @@ Refer: 671 768 N 1 0 0 1 448 -36 2
 EndChar
 
 StartChar: aacute.sc
-Encoding: 65626 -1 1795
+Encoding: 1114202 -1 1795
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -53556,7 +53556,7 @@ Refer: 672 769 N 1 0 0 1 456 -42 2
 EndChar
 
 StartChar: acircumflex.sc
-Encoding: 65627 -1 1796
+Encoding: 1114203 -1 1796
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -53567,7 +53567,7 @@ Refer: 673 770 N 1 0 0 1 392.1 -46 2
 EndChar
 
 StartChar: atilde.sc
-Encoding: 65628 -1 1797
+Encoding: 1114204 -1 1797
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -53578,7 +53578,7 @@ Refer: 674 771 N 1 0 0 1 394 -47 2
 EndChar
 
 StartChar: adieresis.sc
-Encoding: 65629 -1 1798
+Encoding: 1114205 -1 1798
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -53589,7 +53589,7 @@ Refer: 1767 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: aring.sc
-Encoding: 65630 -1 1799
+Encoding: 1114206 -1 1799
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -53600,7 +53600,7 @@ Refer: 1436 805 N 1 0 0 1 616.3 698 2
 EndChar
 
 StartChar: ae.sc
-Encoding: 65631 -1 1800
+Encoding: 1114207 -1 1800
 Width: 629
 GlyphClass: 2
 Flags: MW
@@ -53682,7 +53682,7 @@ EndSplineSet
 EndChar
 
 StartChar: ccedilla.sc
-Encoding: 65632 -1 1801
+Encoding: 1114208 -1 1801
 Width: 494
 GlyphClass: 2
 Flags: MW
@@ -53721,7 +53721,7 @@ EndSplineSet
 EndChar
 
 StartChar: egrave.sc
-Encoding: 65633 -1 1802
+Encoding: 1114209 -1 1802
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -53732,7 +53732,7 @@ Refer: 671 768 N 1 0 0 1 385 -26 2
 EndChar
 
 StartChar: eacute.sc
-Encoding: 65634 -1 1803
+Encoding: 1114210 -1 1803
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -53743,7 +53743,7 @@ Refer: 672 769 N 1 0 0 1 411 -45 2
 EndChar
 
 StartChar: ecircumflex.sc
-Encoding: 65635 -1 1804
+Encoding: 1114211 -1 1804
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -53754,7 +53754,7 @@ Refer: 673 770 N 1 0 0 1 378.1 -47 2
 EndChar
 
 StartChar: edieresis.sc
-Encoding: 65636 -1 1805
+Encoding: 1114212 -1 1805
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -53765,7 +53765,7 @@ Refer: 1771 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: igrave.sc
-Encoding: 65637 -1 1806
+Encoding: 1114213 -1 1806
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -53776,7 +53776,7 @@ Refer: 671 768 N 1 0 0 1 268 -43 2
 EndChar
 
 StartChar: iacute.sc
-Encoding: 65638 -1 1807
+Encoding: 1114214 -1 1807
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -53787,7 +53787,7 @@ Refer: 672 769 N 1 0 0 1 325 -45 2
 EndChar
 
 StartChar: icircumflex.sc
-Encoding: 65639 -1 1808
+Encoding: 1114215 -1 1808
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -53798,7 +53798,7 @@ Refer: 673 770 N 1 0 0 1 274.1 -46 2
 EndChar
 
 StartChar: idieresis.sc
-Encoding: 65640 -1 1809
+Encoding: 1114216 -1 1809
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -53809,7 +53809,7 @@ Refer: 1775 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: eth.sc
-Encoding: 65641 -1 1810
+Encoding: 1114217 -1 1810
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -53856,7 +53856,7 @@ EndSplineSet
 EndChar
 
 StartChar: ntilde.sc
-Encoding: 65642 -1 1811
+Encoding: 1114218 -1 1811
 Width: 591
 GlyphClass: 2
 Flags: MW
@@ -53867,7 +53867,7 @@ Refer: 674 771 N 1 0 0 1 459 -47 2
 EndChar
 
 StartChar: ograve.sc
-Encoding: 65643 -1 1812
+Encoding: 1114219 -1 1812
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -53878,7 +53878,7 @@ Refer: 671 768 N 1 0 0 1 421 -40 2
 EndChar
 
 StartChar: oacute.sc
-Encoding: 65644 -1 1813
+Encoding: 1114220 -1 1813
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -53889,7 +53889,7 @@ Refer: 672 769 N 1 0 0 1 461 -45 2
 EndChar
 
 StartChar: ocircumflex.sc
-Encoding: 65645 -1 1814
+Encoding: 1114221 -1 1814
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -53900,7 +53900,7 @@ Refer: 673 770 N 1 0 0 1 417.1 -50 2
 EndChar
 
 StartChar: otilde.sc
-Encoding: 65646 -1 1815
+Encoding: 1114222 -1 1815
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -53911,7 +53911,7 @@ Refer: 674 771 N 1 0 0 1 423 -47 2
 EndChar
 
 StartChar: odieresis.sc
-Encoding: 65647 -1 1816
+Encoding: 1114223 -1 1816
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -53922,7 +53922,7 @@ Refer: 1781 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: oe.sc
-Encoding: 65648 -1 1817
+Encoding: 1114224 -1 1817
 Width: 688
 GlyphClass: 2
 Flags: MW
@@ -53977,7 +53977,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslash.sc
-Encoding: 65649 -1 1818
+Encoding: 1114225 -1 1818
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -54015,7 +54015,7 @@ EndSplineSet
 EndChar
 
 StartChar: ugrave.sc
-Encoding: 65650 -1 1819
+Encoding: 1114226 -1 1819
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -54026,7 +54026,7 @@ Refer: 671 768 N 1 0 0 1 424 -40 2
 EndChar
 
 StartChar: uacute.sc
-Encoding: 65651 -1 1820
+Encoding: 1114227 -1 1820
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -54037,7 +54037,7 @@ Refer: 672 769 N 1 0 0 1 495 -45 2
 EndChar
 
 StartChar: ucircumflex.sc
-Encoding: 65652 -1 1821
+Encoding: 1114228 -1 1821
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -54048,7 +54048,7 @@ Refer: 673 770 N 1 0 0 1 431.1 -51 2
 EndChar
 
 StartChar: udieresis.sc
-Encoding: 65653 -1 1822
+Encoding: 1114229 -1 1822
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -54059,7 +54059,7 @@ Refer: 1787 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: yacute.sc
-Encoding: 65654 -1 1823
+Encoding: 1114230 -1 1823
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -54070,7 +54070,7 @@ Refer: 672 769 N 1 0 0 1 452 -39 2
 EndChar
 
 StartChar: thorn.sc
-Encoding: 65655 -1 1824
+Encoding: 1114231 -1 1824
 Width: 450
 GlyphClass: 2
 Flags: MW
@@ -54119,7 +54119,7 @@ EndSplineSet
 EndChar
 
 StartChar: ydieresis.sc
-Encoding: 65656 -1 1825
+Encoding: 1114232 -1 1825
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -54130,7 +54130,7 @@ Refer: 1791 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: ij.sc
-Encoding: 65657 -1 1826
+Encoding: 1114233 -1 1826
 Width: 540
 GlyphClass: 2
 Flags: MW
@@ -54141,7 +54141,7 @@ Refer: 1775 -1 N 1 0 0 1 -1 0 2
 EndChar
 
 StartChar: germandbls.scalt
-Encoding: 65658 -1 1827
+Encoding: 1114234 -1 1827
 Width: 769
 GlyphClass: 2
 Flags: MW
@@ -54152,7 +54152,7 @@ Refer: 1785 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: germandbls.sc
-Encoding: 65659 -1 1828
+Encoding: 1114235 -1 1828
 Width: 542
 GlyphClass: 2
 Flags: MW
@@ -58248,7 +58248,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.fitted
-Encoding: 65660 -1 1934
+Encoding: 1114236 -1 1934
 Width: 471
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
@@ -64014,7 +64014,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash
-Encoding: 65661 -1 2063
+Encoding: 1114237 -1 2063
 Width: 444
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
@@ -64045,7 +64045,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.oldstyle
-Encoding: 65662 -1 2065
+Encoding: 1114238 -1 2065
 Width: 441
 GlyphClass: 2
 Flags: MW
@@ -64110,7 +64110,7 @@ EndSplineSet
 EndChar
 
 StartChar: dcroat.sc
-Encoding: 65663 -1 2067
+Encoding: 1114239 -1 2067
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -64120,7 +64120,7 @@ Refer: 1810 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: abreve.sc
-Encoding: 65664 -1 2068
+Encoding: 1114240 -1 2068
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -64131,7 +64131,7 @@ Refer: 1412 774 N 1 0 0 1 429 -16 2
 EndChar
 
 StartChar: aogonek.sc
-Encoding: 65665 -1 2069
+Encoding: 1114241 -1 2069
 Width: 519
 GlyphClass: 2
 Flags: MW
@@ -64189,7 +64189,7 @@ EndSplineSet
 EndChar
 
 StartChar: cacute.sc
-Encoding: 65666 -1 2070
+Encoding: 1114242 -1 2070
 Width: 494
 GlyphClass: 2
 Flags: MW
@@ -64200,7 +64200,7 @@ Refer: 672 769 N 1 0 0 1 435 -34 2
 EndChar
 
 StartChar: ccaron.sc
-Encoding: 65667 -1 2071
+Encoding: 1114243 -1 2071
 Width: 494
 GlyphClass: 2
 Flags: MW
@@ -64211,7 +64211,7 @@ Refer: 1769 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: dcaron.sc
-Encoding: 65668 -1 2072
+Encoding: 1114244 -1 2072
 Width: 551
 GlyphClass: 2
 Flags: MW
@@ -64222,7 +64222,7 @@ Refer: 1770 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: eogonek.sc
-Encoding: 65669 -1 2073
+Encoding: 1114245 -1 2073
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -64287,7 +64287,7 @@ EndSplineSet
 EndChar
 
 StartChar: ecaron.sc
-Encoding: 65670 -1 2074
+Encoding: 1114246 -1 2074
 Width: 457
 GlyphClass: 2
 Flags: MW
@@ -64298,7 +64298,7 @@ Refer: 1771 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: gbreve.sc
-Encoding: 65671 -1 2075
+Encoding: 1114247 -1 2075
 Width: 539
 GlyphClass: 2
 Flags: MW
@@ -64309,7 +64309,7 @@ Refer: 1412 774 N 1 0 0 1 449 -16 2
 EndChar
 
 StartChar: lacute.sc
-Encoding: 65672 -1 2076
+Encoding: 1114248 -1 2076
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -64320,7 +64320,7 @@ Refer: 672 769 N 1 0 0 1 360 -38 2
 EndChar
 
 StartChar: lslash.sc
-Encoding: 65673 -1 2077
+Encoding: 1114249 -1 2077
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -64369,7 +64369,7 @@ EndSplineSet
 EndChar
 
 StartChar: nacute.sc
-Encoding: 65674 -1 2078
+Encoding: 1114250 -1 2078
 Width: 591
 GlyphClass: 2
 Flags: MW
@@ -64380,7 +64380,7 @@ Refer: 672 769 N 1 0 0 1 424 -37 2
 EndChar
 
 StartChar: ncaron.sc
-Encoding: 65675 -1 2079
+Encoding: 1114251 -1 2079
 Width: 591
 GlyphClass: 2
 Flags: MW
@@ -64391,7 +64391,7 @@ Refer: 1780 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: eng.sc
-Encoding: 65676 -1 2080
+Encoding: 1114252 -1 2080
 Width: 537
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
@@ -64446,7 +64446,7 @@ EndSplineSet
 EndChar
 
 StartChar: ohungarumlaut.sc
-Encoding: 65677 -1 2081
+Encoding: 1114253 -1 2081
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -64457,7 +64457,7 @@ Refer: 1781 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: racute.sc
-Encoding: 65678 -1 2082
+Encoding: 1114254 -1 2082
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -64468,7 +64468,7 @@ Refer: 672 769 N 1 0 0 1 407 -38 2
 EndChar
 
 StartChar: rcaron.sc
-Encoding: 65679 -1 2083
+Encoding: 1114255 -1 2083
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -64479,7 +64479,7 @@ Refer: 1784 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: sacute.sc
-Encoding: 65680 -1 2084
+Encoding: 1114256 -1 2084
 Width: 383
 GlyphClass: 2
 Flags: MW
@@ -64490,7 +64490,7 @@ Refer: 672 769 N 1 0 0 1 383 -38 2
 EndChar
 
 StartChar: scedilla.sc
-Encoding: 65681 -1 2085
+Encoding: 1114257 -1 2085
 Width: 383
 GlyphClass: 2
 Flags: MW
@@ -64538,7 +64538,7 @@ EndSplineSet
 EndChar
 
 StartChar: scaron.sc
-Encoding: 65682 -1 2086
+Encoding: 1114258 -1 2086
 Width: 383
 GlyphClass: 2
 Flags: MW
@@ -64549,7 +64549,7 @@ Refer: 1785 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni0163.sc
-Encoding: 65683 -1 2087
+Encoding: 1114259 -1 2087
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -64604,7 +64604,7 @@ EndSplineSet
 EndChar
 
 StartChar: tbar.sc
-Encoding: 65684 -1 2088
+Encoding: 1114260 -1 2088
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -64655,7 +64655,7 @@ EndSplineSet
 EndChar
 
 StartChar: uring.sc
-Encoding: 65685 -1 2089
+Encoding: 1114261 -1 2089
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -64666,7 +64666,7 @@ Refer: 1413 778 N 1 0 0 1 457 -61 2
 EndChar
 
 StartChar: uhungarumlaut.sc
-Encoding: 65686 -1 2090
+Encoding: 1114262 -1 2090
 Width: 568
 GlyphClass: 2
 Flags: MW
@@ -64677,7 +64677,7 @@ Refer: 1787 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zacute.sc
-Encoding: 65687 -1 2091
+Encoding: 1114263 -1 2091
 Width: 470
 GlyphClass: 2
 Flags: MW
@@ -64688,7 +64688,7 @@ Refer: 672 769 N 1 0 0 1 405 -34 2
 EndChar
 
 StartChar: zdotaccent.sc
-Encoding: 65688 -1 2092
+Encoding: 1114264 -1 2092
 Width: 470
 GlyphClass: 2
 Flags: MW
@@ -64699,7 +64699,7 @@ Refer: 1792 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zcaron.sc
-Encoding: 65689 -1 2093
+Encoding: 1114265 -1 2093
 Width: 470
 GlyphClass: 2
 Flags: MW
@@ -64710,7 +64710,7 @@ Refer: 1792 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: lcaron.sc
-Encoding: 65690 -1 2094
+Encoding: 1114266 -1 2094
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -64721,7 +64721,7 @@ Refer: 1778 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: tcaron.sc
-Encoding: 65691 -1 2095
+Encoding: 1114267 -1 2095
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -64732,7 +64732,7 @@ Refer: 1786 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: .notdef
-Encoding: 65692 -1 2096
+Encoding: 1114268 -1 2096
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -64787,7 +64787,7 @@ EndSplineSet
 EndChar
 
 StartChar: kreis
-Encoding: 65693 -1 2098
+Encoding: 1114269 -1 2098
 Width: 633
 Flags: MW
 LayerCount: 2
@@ -64807,7 +64807,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.scalt
-Encoding: 65694 -1 2099
+Encoding: 1114270 -1 2099
 Width: 485
 GlyphClass: 2
 Flags: MW
@@ -65159,7 +65159,7 @@ Refer: 2317 8346 N 1 0 0 1 103 476 2
 EndChar
 
 StartChar: q.superior
-Encoding: 65695 -1 2111
+Encoding: 1114271 -1 2111
 Width: 294
 GlyphClass: 2
 Flags: MW
@@ -65326,7 +65326,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0E8
-Encoding: 65696 -1 2116
+Encoding: 1114272 -1 2116
 Width: 575
 Flags: MW
 LayerCount: 2
@@ -65374,7 +65374,7 @@ EndSplineSet
 EndChar
 
 StartChar: W.alt.2
-Encoding: 65697 -1 2117
+Encoding: 1114273 -1 2117
 Width: 893
 Flags: MW
 LayerCount: 2
@@ -65435,7 +65435,7 @@ EndSplineSet
 EndChar
 
 StartChar: V.alt
-Encoding: 65698 -1 2118
+Encoding: 1114274 -1 2118
 Width: 604
 Flags: MW
 LayerCount: 2
@@ -65480,7 +65480,7 @@ EndSplineSet
 EndChar
 
 StartChar: K.alt
-Encoding: 65699 -1 2119
+Encoding: 1114275 -1 2119
 Width: 625
 GlyphClass: 2
 Flags: MW
@@ -65540,7 +65540,7 @@ EndSplineSet
 EndChar
 
 StartChar: R.alt
-Encoding: 65700 -1 2120
+Encoding: 1114276 -1 2120
 Width: 574
 GlyphClass: 2
 Flags: MW
@@ -65591,7 +65591,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0F9
-Encoding: 65701 -1 2121
+Encoding: 1114277 -1 2121
 Width: 623
 Flags: MW
 LayerCount: 2
@@ -65602,7 +65602,7 @@ Refer: 1054 8219 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE0FB
-Encoding: 65702 -1 2122
+Encoding: 1114278 -1 2122
 Width: 640
 Flags: MW
 LayerCount: 2
@@ -65613,7 +65613,7 @@ Refer: 255 44 N 1 0 0 1 141 603 2
 EndChar
 
 StartChar: t_z
-Encoding: 65703 -1 2123
+Encoding: 1114279 -1 2123
 Width: 497
 GlyphClass: 3
 Flags: MW
@@ -65656,7 +65656,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.alt
-Encoding: 65704 -1 2124
+Encoding: 1114280 -1 2124
 Width: 517
 GlyphClass: 2
 Flags: MW
@@ -65685,7 +65685,7 @@ EndSplineSet
 EndChar
 
 StartChar: Tux
-Encoding: 65705 -1 2125
+Encoding: 1114281 -1 2125
 Width: 760
 Flags: MW
 LayerCount: 2
@@ -65865,7 +65865,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.taboldstyle
-Encoding: 65706 -1 2126
+Encoding: 1114282 -1 2126
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65886,7 +65886,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.taboldstyle
-Encoding: 65707 -1 2127
+Encoding: 1114283 -1 2127
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65912,7 +65912,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.taboldstyle
-Encoding: 65708 -1 2128
+Encoding: 1114284 -1 2128
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65922,7 +65922,7 @@ Refer: 2065 -1 N 1 0 0 1 -1 0 2
 EndChar
 
 StartChar: three.taboldstyle
-Encoding: 65709 -1 2129
+Encoding: 1114285 -1 2129
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65932,7 +65932,7 @@ Refer: 12 51 N 1 0 0 1 -40 -171 2
 EndChar
 
 StartChar: four.taboldstyle
-Encoding: 65710 -1 2130
+Encoding: 1114286 -1 2130
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -65942,7 +65942,7 @@ Refer: 13 52 N 1 0 0 1 -52.0003 -172 2
 EndChar
 
 StartChar: five.taboldstyle
-Encoding: 65711 -1 2131
+Encoding: 1114287 -1 2131
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65952,7 +65952,7 @@ Refer: 14 53 N 1 0 0 1 -40 -172 2
 EndChar
 
 StartChar: six.taboldstyle
-Encoding: 65712 -1 2132
+Encoding: 1114288 -1 2132
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65962,7 +65962,7 @@ Refer: 15 54 N 1 0 0 1 -8 0.0201103 2
 EndChar
 
 StartChar: seven.taboldstyle
-Encoding: 65713 -1 2133
+Encoding: 1114289 -1 2133
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65972,7 +65972,7 @@ Refer: 16 55 N 1 0 0 1 -52 -171 2
 EndChar
 
 StartChar: eight.taboldstyle
-Encoding: 65714 -1 2134
+Encoding: 1114290 -1 2134
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -65982,7 +65982,7 @@ Refer: 2066 56 N 1 0 0 1 -6 0 2
 EndChar
 
 StartChar: nine.taboldstyle
-Encoding: 65715 -1 2135
+Encoding: 1114291 -1 2135
 Width: 444
 GlyphClass: 2
 Flags: MW
@@ -66572,7 +66572,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.ss03
-Encoding: 65716 -1 2151
+Encoding: 1114292 -1 2151
 Width: 752
 GlyphClass: 2
 Flags: MW
@@ -66619,7 +66619,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.alt
-Encoding: 65717 -1 2152
+Encoding: 1114293 -1 2152
 Width: 543
 GlyphClass: 2
 Flags: MW
@@ -66665,7 +66665,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni1E9C.alt
-Encoding: 65718 -1 2153
+Encoding: 1114294 -1 2153
 Width: 947
 Flags: MW
 LayerCount: 2
@@ -66675,7 +66675,7 @@ Refer: 270 83 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE00B
-Encoding: 65719 -1 2154
+Encoding: 1114295 -1 2154
 Width: 453
 Flags: MW
 AnchorPoint: "below" 213 -113 basechar 0
@@ -66707,7 +66707,7 @@ EndSplineSet
 EndChar
 
 StartChar: J.alt
-Encoding: 65720 -1 2155
+Encoding: 1114296 -1 2155
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -66737,7 +66737,7 @@ EndSplineSet
 EndChar
 
 StartChar: z.alt
-Encoding: 65721 -1 2156
+Encoding: 1114297 -1 2156
 Width: 449
 Flags: MW
 LayerCount: 2
@@ -68050,7 +68050,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni021B.sc
-Encoding: 65722 -1 2183
+Encoding: 1114298 -1 2183
 Width: 492
 GlyphClass: 2
 Flags: MW
@@ -68061,7 +68061,7 @@ Refer: 682 806 N 1 0 0 1 499 -21 2
 EndChar
 
 StartChar: uni0219.sc
-Encoding: 65723 -1 2184
+Encoding: 1114299 -1 2184
 Width: 383
 GlyphClass: 2
 Flags: MW
@@ -68072,7 +68072,7 @@ Refer: 682 806 N 1 0 0 1 436 -21 2
 EndChar
 
 StartChar: idotaccent.sc
-Encoding: 65724 -1 2185
+Encoding: 1114300 -1 2185
 Width: 277
 GlyphClass: 2
 Flags: MW
@@ -68083,7 +68083,7 @@ Refer: 675 775 N 1 0 0 1 304 -34 2
 EndChar
 
 StartChar: hyphen.cap
-Encoding: 65725 -1 2186
+Encoding: 1114301 -1 2186
 Width: 333
 GlyphClass: 2
 Flags: MW
@@ -68093,7 +68093,7 @@ Refer: 256 45 N 1 0 0 1 25 60 2
 EndChar
 
 StartChar: b.inferior
-Encoding: 65726 -1 2187
+Encoding: 1114302 -1 2187
 Width: 285
 GlyphClass: 2
 Flags: MW
@@ -68103,7 +68103,7 @@ Refer: 2101 7495 N 1 0 0 1 -110 -476 2
 EndChar
 
 StartChar: c.inferior
-Encoding: 65727 -1 2188
+Encoding: 1114303 -1 2188
 Width: 270
 GlyphClass: 2
 Flags: MW
@@ -68113,7 +68113,7 @@ Refer: 2102 7580 N 1 0 0 1 -112 -476 2
 EndChar
 
 StartChar: d.inferior
-Encoding: 65728 -1 2189
+Encoding: 1114304 -1 2189
 Width: 295
 GlyphClass: 2
 Flags: MW
@@ -68123,7 +68123,7 @@ Refer: 2103 7496 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: f.inferior
-Encoding: 65729 -1 2190
+Encoding: 1114305 -1 2190
 Width: 242
 GlyphClass: 2
 Flags: MW
@@ -68133,7 +68133,7 @@ Refer: 2105 7584 N 1 0 0 1 -117 -476 2
 EndChar
 
 StartChar: g.inferior
-Encoding: 65730 -1 2191
+Encoding: 1114306 -1 2191
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -68143,7 +68143,7 @@ Refer: 2106 7501 N 1 0 0 1 -98 -474 2
 EndChar
 
 StartChar: h.inferior
-Encoding: 65731 -1 2192
+Encoding: 1114307 -1 2192
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -68153,7 +68153,7 @@ Refer: 1456 688 N 1 0 0 1 -93 -476 2
 EndChar
 
 StartChar: i.inferior
-Encoding: 65732 -1 2193
+Encoding: 1114308 -1 2193
 Width: 194
 GlyphClass: 2
 Flags: MW
@@ -68163,7 +68163,7 @@ Refer: 1073 8305 N 1 0 0 1 -112 -476 2
 EndChar
 
 StartChar: j.inferior
-Encoding: 65733 -1 2194
+Encoding: 1114309 -1 2194
 Width: 207
 GlyphClass: 2
 Flags: MW
@@ -68173,7 +68173,7 @@ Refer: 1457 690 N 1 0 0 1 -93 -476 2
 EndChar
 
 StartChar: k.inferior
-Encoding: 65734 -1 2195
+Encoding: 1114310 -1 2195
 Width: 305
 GlyphClass: 2
 Flags: MW
@@ -68183,7 +68183,7 @@ Refer: 2315 8342 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: l.inferior
-Encoding: 65735 -1 2196
+Encoding: 1114311 -1 2196
 Width: 161
 GlyphClass: 2
 Flags: MW
@@ -68193,7 +68193,7 @@ Refer: 1940 737 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: m.inferior
-Encoding: 65736 -1 2197
+Encoding: 1114312 -1 2197
 Width: 464
 GlyphClass: 2
 Flags: MW
@@ -68203,7 +68203,7 @@ Refer: 2136 8344 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: n.inferior
-Encoding: 65737 -1 2198
+Encoding: 1114313 -1 2198
 Width: 329
 GlyphClass: 2
 Flags: MW
@@ -68213,7 +68213,7 @@ Refer: 1085 8319 N 1 0 0 1 -88 -476 2
 EndChar
 
 StartChar: p.inferior
-Encoding: 65738 -1 2199
+Encoding: 1114314 -1 2199
 Width: 305
 GlyphClass: 2
 Flags: MW
@@ -68223,7 +68223,7 @@ Refer: 2317 8346 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: q.inferior
-Encoding: 65739 -1 2200
+Encoding: 1114315 -1 2200
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -68233,7 +68233,7 @@ Refer: 2111 -1 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: r.inferior
-Encoding: 65740 -1 2201
+Encoding: 1114316 -1 2201
 Width: 246
 GlyphClass: 2
 Flags: MW
@@ -68243,7 +68243,7 @@ Refer: 1458 691 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: s.inferior
-Encoding: 65741 -1 2202
+Encoding: 1114317 -1 2202
 Width: 253
 GlyphClass: 2
 Flags: MW
@@ -68253,7 +68253,7 @@ Refer: 1941 738 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: t.inferior
-Encoding: 65742 -1 2203
+Encoding: 1114318 -1 2203
 Width: 197
 GlyphClass: 2
 Flags: MW
@@ -68263,7 +68263,7 @@ Refer: 2319 8348 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: u.inferior
-Encoding: 65743 -1 2204
+Encoding: 1114319 -1 2204
 Width: 306
 GlyphClass: 2
 Flags: MW
@@ -68273,7 +68273,7 @@ Refer: 2113 7512 N 1 0 0 1 -103 -476 2
 EndChar
 
 StartChar: v.inferior
-Encoding: 65744 -1 2205
+Encoding: 1114320 -1 2205
 Width: 301
 GlyphClass: 2
 Flags: MW
@@ -68283,7 +68283,7 @@ Refer: 2114 7515 N 1 0 0 1 -112 -476 2
 EndChar
 
 StartChar: w.inferior
-Encoding: 65745 -1 2206
+Encoding: 1114321 -1 2206
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -68293,7 +68293,7 @@ Refer: 1460 695 N 1 0 0 1 -86 -476 2
 EndChar
 
 StartChar: y.inferior
-Encoding: 65746 -1 2207
+Encoding: 1114322 -1 2207
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -68303,7 +68303,7 @@ Refer: 1391 696 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: z.inferior
-Encoding: 65747 -1 2208
+Encoding: 1114323 -1 2208
 Width: 262
 GlyphClass: 2
 Flags: MW
@@ -68313,7 +68313,7 @@ Refer: 2115 7611 N 1 0 0 1 -107 -476 2
 EndChar
 
 StartChar: uniE0F4
-Encoding: 65748 -1 2209
+Encoding: 1114324 -1 2209
 Width: 424
 Flags: MW
 LayerCount: 2
@@ -68348,7 +68348,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE130
-Encoding: 65749 -1 2210
+Encoding: 1114325 -1 2210
 Width: 166
 Flags: MW
 LayerCount: 2
@@ -68357,7 +68357,7 @@ Refer: 256 45 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: y.alt
-Encoding: 65750 -1 2211
+Encoding: 1114326 -1 2211
 Width: 511
 GlyphClass: 2
 Flags: MW
@@ -68399,7 +68399,7 @@ EndSplineSet
 EndChar
 
 StartChar: grave.cap
-Encoding: 65751 -1 2212
+Encoding: 1114327 -1 2212
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68418,7 +68418,7 @@ EndSplineSet
 EndChar
 
 StartChar: acute.cap
-Encoding: 65752 -1 2213
+Encoding: 1114328 -1 2213
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68436,7 +68436,7 @@ EndSplineSet
 EndChar
 
 StartChar: circumflex.cap
-Encoding: 65753 -1 2214
+Encoding: 1114329 -1 2214
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68455,7 +68455,7 @@ EndSplineSet
 EndChar
 
 StartChar: caron.cap
-Encoding: 65754 -1 2215
+Encoding: 1114330 -1 2215
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68474,7 +68474,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cap
-Encoding: 65755 -1 2216
+Encoding: 1114331 -1 2216
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68493,7 +68493,7 @@ EndSplineSet
 EndChar
 
 StartChar: hungarumlaut.cap
-Encoding: 65756 -1 2217
+Encoding: 1114332 -1 2217
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68522,7 +68522,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni030F.cap
-Encoding: 65757 -1 2218
+Encoding: 1114333 -1 2218
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68551,7 +68551,7 @@ EndSplineSet
 EndChar
 
 StartChar: breveinvertedcmb.cap
-Encoding: 65758 -1 2219
+Encoding: 1114334 -1 2219
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68571,7 +68571,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyrcap
-Encoding: 65759 -1 2220
+Encoding: 1114335 -1 2220
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68591,7 +68591,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyr
-Encoding: 65760 -1 2221
+Encoding: 1114336 -1 2221
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68611,7 +68611,7 @@ EndSplineSet
 EndChar
 
 StartChar: dieresis.cap
-Encoding: 65761 -1 2222
+Encoding: 1114337 -1 2222
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -68636,7 +68636,7 @@ EndSplineSet
 EndChar
 
 StartChar: hookabovecomb.cap
-Encoding: 65762 -1 2223
+Encoding: 1114338 -1 2223
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -70448,7 +70448,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.short
-Encoding: 65763 -1 2299
+Encoding: 1114339 -1 2299
 Width: 323
 GlyphClass: 2
 Flags: MW
@@ -70491,7 +70491,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f.short
-Encoding: 65764 -1 2300
+Encoding: 1114340 -1 2300
 Width: 612
 GlyphClass: 3
 Flags: MW
@@ -70553,7 +70553,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE00C
-Encoding: 65765 -1 2301
+Encoding: 1114341 -1 2301
 Width: 675
 Flags: MW
 AnchorPoint: "below" 332 -111 basechar 0
@@ -70594,7 +70594,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE00D
-Encoding: 65766 -1 2302
+Encoding: 1114342 -1 2302
 Width: 475
 Flags: MW
 AnchorPoint: "below" 368 -107 basechar 0
@@ -70630,7 +70630,7 @@ EndSplineSet
 EndChar
 
 StartChar: v.alt
-Encoding: 65767 -1 2303
+Encoding: 1114343 -1 2303
 Width: 540
 Flags: MW
 LayerCount: 2
@@ -70665,7 +70665,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE138
-Encoding: 65768 -1 2304
+Encoding: 1114344 -1 2304
 Width: 1014
 Flags: MW
 LayerCount: 2
@@ -70713,7 +70713,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0431.ital
-Encoding: 65769 -1 2305
+Encoding: 1114345 -1 2305
 Width: 468
 GlyphClass: 2
 Flags: MW
@@ -70743,7 +70743,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni043F.ital
-Encoding: 65770 -1 2306
+Encoding: 1114346 -1 2306
 Width: 521
 GlyphClass: 2
 Flags: MW
@@ -70754,7 +70754,7 @@ Refer: 303 117 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni0433.ital
-Encoding: 65771 -1 2307
+Encoding: 1114347 -1 2307
 Width: 268
 GlyphClass: 2
 Flags: MW
@@ -70773,7 +70773,7 @@ Refer: 421 305 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni0434.ital
-Encoding: 65772 -1 2308
+Encoding: 1114348 -1 2308
 Width: 499
 GlyphClass: 2
 Flags: MW
@@ -70804,7 +70804,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0442.ital
-Encoding: 65773 -1 2309
+Encoding: 1114349 -1 2309
 Width: 792
 GlyphClass: 2
 Flags: MW
@@ -70823,7 +70823,7 @@ Refer: 97 1096 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE01C
-Encoding: 65774 -1 2310
+Encoding: 1114350 -1 2310
 Width: 255
 Flags: MW
 LayerCount: 2
@@ -70849,7 +70849,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE00E
-Encoding: 65775 -1 2311
+Encoding: 1114351 -1 2311
 Width: 472
 Flags: MW
 LayerCount: 2
@@ -70858,7 +70858,7 @@ Refer: 304 118 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE188
-Encoding: 65776 -1 2312
+Encoding: 1114352 -1 2312
 Width: 388
 Flags: MW
 LayerCount: 2
@@ -70891,7 +70891,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE189
-Encoding: 65777 -1 2313
+Encoding: 1114353 -1 2313
 Width: 388
 Flags: MW
 LayerCount: 2
@@ -71086,7 +71086,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_j
-Encoding: 65778 -1 2320
+Encoding: 1114354 -1 2320
 Width: 584
 GlyphClass: 3
 Flags: MW
@@ -71141,7 +71141,7 @@ LCarets2: 1 287
 EndChar
 
 StartChar: f_f_j
-Encoding: 65779 -1 2321
+Encoding: 1114355 -1 2321
 Width: 819
 GlyphClass: 3
 Flags: MW
@@ -71240,7 +71240,7 @@ Refer: 2047 9002 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: q.sc.u
-Encoding: 65780 -1 2324
+Encoding: 1114356 -1 2324
 Width: 546
 GlyphClass: 2
 Flags: MW
@@ -71357,7 +71357,7 @@ EndSplineSet
 EndChar
 
 StartChar: aeacute.sc
-Encoding: 65781 -1 2326
+Encoding: 1114357 -1 2326
 Width: 629
 VWidth: 0
 GlyphClass: 2
@@ -71368,7 +71368,7 @@ Refer: 1800 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni01E3.sc
-Encoding: 65782 -1 2327
+Encoding: 1114358 -1 2327
 Width: 629
 VWidth: 0
 GlyphClass: 2
@@ -71379,7 +71379,7 @@ Refer: 1800 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65783 -1 2328
+Encoding: 1114359 -1 2328
 Width: 666
 GlyphClass: 2
 Flags: W
@@ -71440,7 +71440,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle.sc
-Encoding: 65784 -1 2329
+Encoding: 1114360 -1 2329
 Width: 613
 GlyphClass: 2
 Flags: W
@@ -71501,7 +71501,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_i
-Encoding: 65785 -1 2330
+Encoding: 1114361 -1 2330
 Width: 564
 GlyphClass: 3
 Flags: W
@@ -71538,7 +71538,7 @@ Refer: 421 305 N 1 0 0 1 279 0 2
 EndChar
 
 StartChar: longs_j
-Encoding: 65786 -1 2331
+Encoding: 1114362 -1 2331
 Width: 564
 GlyphClass: 3
 Flags: W
@@ -71575,7 +71575,7 @@ Refer: 1721 567 N 1 0 0 1 272 0 2
 EndChar
 
 StartChar: longs_l
-Encoding: 65787 -1 2332
+Encoding: 1114363 -1 2332
 Width: 570
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -71625,7 +71625,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_longs
-Encoding: 65788 -1 2333
+Encoding: 1114364 -1 2333
 Width: 547
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -71682,7 +71682,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_longs_i
-Encoding: 65789 -1 2334
+Encoding: 1114365 -1 2334
 Width: 821
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -71744,7 +71744,7 @@ Refer: 421 305 N 1 0 0 1 537 0 2
 EndChar
 
 StartChar: longs_longs_j
-Encoding: 65790 -1 2335
+Encoding: 1114366 -1 2335
 Width: 822
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -71806,7 +71806,7 @@ Refer: 1721 567 N 1 0 0 1 532 0 2
 EndChar
 
 StartChar: longs_longs_l
-Encoding: 65791 -1 2336
+Encoding: 1114367 -1 2336
 Width: 828
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -71916,7 +71916,7 @@ LayerCount: 2
 EndChar
 
 StartChar: zero.slash.cap
-Encoding: 65792 -1 2341
+Encoding: 1114368 -1 2341
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -71929,7 +71929,7 @@ Refer: 2342 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.cap
-Encoding: 65793 -1 2342
+Encoding: 1114369 -1 2342
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -71956,7 +71956,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.cap
-Encoding: 65794 -1 2343
+Encoding: 1114370 -1 2343
 Width: 479
 VWidth: 1078
 GlyphClass: 2
@@ -71987,7 +71987,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.cap
-Encoding: 65795 -1 2344
+Encoding: 1114371 -1 2344
 Width: 479
 VWidth: 1078
 GlyphClass: 2
@@ -72023,7 +72023,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.cap
-Encoding: 65796 -1 2345
+Encoding: 1114372 -1 2345
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72057,7 +72057,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.cap
-Encoding: 65797 -1 2346
+Encoding: 1114373 -1 2346
 Width: 480
 VWidth: 1078
 GlyphClass: 2
@@ -72095,7 +72095,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.cap
-Encoding: 65798 -1 2347
+Encoding: 1114374 -1 2347
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72127,7 +72127,7 @@ EndSplineSet
 EndChar
 
 StartChar: six.cap
-Encoding: 65799 -1 2348
+Encoding: 1114375 -1 2348
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72155,7 +72155,7 @@ EndSplineSet
 EndChar
 
 StartChar: seven.cap
-Encoding: 65800 -1 2349
+Encoding: 1114376 -1 2349
 Width: 479
 VWidth: 1076
 GlyphClass: 2
@@ -72182,7 +72182,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.cap
-Encoding: 65801 -1 2350
+Encoding: 1114377 -1 2350
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72218,7 +72218,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.cap
-Encoding: 65802 -1 2351
+Encoding: 1114378 -1 2351
 Width: 479
 VWidth: 1077
 GlyphClass: 2
@@ -72246,7 +72246,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.cap.fitted
-Encoding: 65803 -1 2352
+Encoding: 1114379 -1 2352
 Width: 505
 VWidth: 1077
 GlyphClass: 2
@@ -72259,7 +72259,7 @@ Refer: 2353 -1 N 1 0 0 1 3.48633 0 2
 EndChar
 
 StartChar: zero.cap.fitted
-Encoding: 65804 -1 2353
+Encoding: 1114380 -1 2353
 Width: 505
 VWidth: 1077
 GlyphClass: 2
@@ -72270,7 +72270,7 @@ Refer: 2342 -1 N 1 0 0 1 16 0 2
 EndChar
 
 StartChar: one.cap.fitted
-Encoding: 65805 -1 2354
+Encoding: 1114381 -1 2354
 Width: 402
 VWidth: 1078
 GlyphClass: 2
@@ -72281,7 +72281,7 @@ Refer: 2343 -1 N 1 0 0 1 -40.1038 0 2
 EndChar
 
 StartChar: two.cap.fitted
-Encoding: 65806 -1 2355
+Encoding: 1114382 -1 2355
 Width: 494
 VWidth: 1078
 GlyphClass: 2
@@ -72292,7 +72292,7 @@ Refer: 2344 -1 N 1 0 0 1 10 0 2
 EndChar
 
 StartChar: three.cap.fitted
-Encoding: 65807 -1 2356
+Encoding: 1114383 -1 2356
 Width: 487
 VWidth: 1077
 GlyphClass: 2
@@ -72303,7 +72303,7 @@ Refer: 2345 -1 N 1 0 0 1 8 0 2
 EndChar
 
 StartChar: four.cap.fitted
-Encoding: 65808 -1 2357
+Encoding: 1114384 -1 2357
 Width: 493
 VWidth: 1078
 GlyphClass: 2
@@ -72314,7 +72314,7 @@ Refer: 2346 -1 N 1 0 0 1 2.82874 0 2
 EndChar
 
 StartChar: five.cap.fitted
-Encoding: 65809 -1 2358
+Encoding: 1114385 -1 2358
 Width: 483
 VWidth: 1077
 GlyphClass: 2
@@ -72325,7 +72325,7 @@ Refer: 2347 -1 N 1 0 0 1 3 0 2
 EndChar
 
 StartChar: six.cap.fitted
-Encoding: 65810 -1 2359
+Encoding: 1114386 -1 2359
 Width: 501
 VWidth: 1077
 GlyphClass: 2
@@ -72336,7 +72336,7 @@ Refer: 2348 -1 N 1 0 0 1 14 0 2
 EndChar
 
 StartChar: seven.cap.fitted
-Encoding: 65811 -1 2360
+Encoding: 1114387 -1 2360
 Width: 451
 VWidth: 1076
 GlyphClass: 2
@@ -72347,7 +72347,7 @@ Refer: 2349 -1 N 1 0 0 1 -30 0 2
 EndChar
 
 StartChar: eight.cap.fitted
-Encoding: 65812 -1 2361
+Encoding: 1114388 -1 2361
 Width: 496
 VWidth: 1077
 GlyphClass: 2
@@ -72358,7 +72358,7 @@ Refer: 2350 -1 N 1 0 0 1 12 0 2
 EndChar
 
 StartChar: nine.cap.fitted
-Encoding: 65813 -1 2362
+Encoding: 1114389 -1 2362
 Width: 484
 VWidth: 1077
 GlyphClass: 2
@@ -72369,7 +72369,7 @@ Refer: 2351 -1 N 1 0 0 1 9.31371 0 2
 EndChar
 
 StartChar: zslash.cap.util
-Encoding: 65814 -1 2363
+Encoding: 1114390 -1 2363
 Width: 444
 Flags: W
 LayerCount: 2
@@ -72384,7 +72384,7 @@ EndSplineSet
 EndChar
 
 StartChar: zslash.util
-Encoding: 65815 -1 2364
+Encoding: 1114391 -1 2364
 Width: 444
 Flags: W
 LayerCount: 2
@@ -72439,7 +72439,7 @@ Refer: 2102 7580 N -1 0 0 -1 510 995 2
 EndChar
 
 StartChar: uni1E9E.alt
-Encoding: 65816 -1 2369
+Encoding: 1114392 -1 2369
 Width: 906
 GlyphClass: 2
 Flags: W
@@ -72450,7 +72450,7 @@ Refer: 270 83 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: W.alt
-Encoding: 65817 -1 2370
+Encoding: 1114393 -1 2370
 Width: 1037
 GlyphClass: 2
 Flags: W
@@ -72505,7 +72505,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0249.dotless
-Encoding: 65818 -1 2371
+Encoding: 1114394 -1 2371
 Width: 285
 GlyphClass: 2
 Flags: W
@@ -72542,7 +72542,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0268.dotless
-Encoding: 65819 -1 2372
+Encoding: 1114395 -1 2372
 Width: 288
 GlyphClass: 2
 Flags: W
@@ -72591,7 +72591,7 @@ Refer: 2371 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: f_f_h
-Encoding: 65820 -1 2374
+Encoding: 1114396 -1 2374
 Width: 1068
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -72680,7 +72680,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f_k
-Encoding: 65821 -1 2375
+Encoding: 1114397 -1 2375
 Width: 1047
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -72773,7 +72773,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_h
-Encoding: 65822 -1 2376
+Encoding: 1114398 -1 2376
 Width: 818
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -72837,7 +72837,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_s
-Encoding: 65823 -1 2377
+Encoding: 1114399 -1 2377
 Width: 563
 GlyphClass: 3
 Flags: W
@@ -72848,7 +72848,7 @@ Refer: 499 383 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: f_h
-Encoding: 65824 -1 2378
+Encoding: 1114400 -1 2378
 Width: 818
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -72920,7 +72920,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni1EFB
-Encoding: 65825 -1 2379
+Encoding: 1114401 -1 2379
 Width: 0
 VWidth: 0
 Flags: W

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -138,7 +138,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  59 c d e o q ccedilla eogonek oe uni0188 uni018D ohorn c_k c_h
  70 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent uni022F
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -142,7 +142,7 @@ KernClass2: 21 21 "'kern' Latin kerning"
  67 e c o d q ccedilla eogonek oe uni0188 uni018D ohorn uni01DD c_k c_h
  70 a g s aacute ae eacute oacute oslash aogonek cacute edotaccent uni022F
  18 m n p r z dotlessi
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  27 J j Jcircumflex jcircumflex
  178 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright
  57 exclam question exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSerif-Semibold.sfd
+++ b/sources/LibertinusSerif-Semibold.sfd
@@ -81,7 +81,7 @@ KernClass2: 22 20 "'kern' Kerning 1"
  217 c e o q ccedilla eogonek oe uni0188 uni018D ohorn uni01DD alpha omicron sigma phi uni03F2 uni03F5 uni0435 uni043E uni0441 uni0454 uni04D9 uni04E9 uni1E19 uni1E1B uni1EB9 uni1ECD c_k c_h c.sc g.sc o.sc q.sc ccedilla.sc
  218 a d aacute ae eacute oacute oslash aogonek cacute edotaccent omacron uni022F alphatonos rho sigma1 omega omicrontonos phi1 uni03F1 uni0430 uni0437 uni0444 uni044D uni044F uni04D5 uni1E0F uni1EA1 uni1F71 uni1F73 uni1F79
  195 g m n p r s u z uni0237 gamma eta iota kappa uni03BC uni03F0 uni0432 uni0433 uni0438 uni043A uni043C uni043D uni043F uni0440 uni0445 uni0446 uni0448 uni0449 uni045A uni045F uni1EE5 germandbls.alt
- 34 parenright bracketright braceright backslash
+ 44 parenright bracketright braceright backslash
  40 J j Jcircumflex jcircumflex uni0458 j.sc
  132 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide endash emdash uni2015 hyphen.sc
  258 exclam question b h k l thorn hcircumflex hbar uni0137 lacute uni013C lcaron ldot lslash uni0180 uni1E03 uni1E05 uni1E07 uni1E23 uni1E25 uni1E27 uni1E29 uni1E2B uni1E31 uni1E33 uni1E35 uni1E37 uni1E39 uni1E3B uni1E3D exclamdbl uni203D uni2047 uni2048 uni2049

--- a/sources/LibertinusSerif-Semibold.sfd
+++ b/sources/LibertinusSerif-Semibold.sfd
@@ -91,7 +91,7 @@ KernClass2: 22 20 "'kern' Kerning 1"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 61 {} 37 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 24 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -49 {} 0 {} 0 {} -59 {} 0 {} 37 {} -49 {} 24 {} 0 {} 24 {} 24 {} 24 {} -37 {} -66 {} -24 {} 0 {} -61 {} -81 {} -71 {} -49 {} -49 {} 0 {} 0 {} -49 {} 0 {} 24 {} -68 {} 24 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -49 {} -44 {} -39 {} 0 {} 0 {} -49 {} 0 {} 24 {} -112 {} 24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 24 {} 0 {} 37 {} 0 {} -5 {} -34 {} -24 {} 5 {} 10 {} 10 {} 0 {} -29 {} -29 {} 5 {} 5 {} 0 {} -12 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 10 {} 10 {} 0 {} -49 {} -39 {} -5 {} 0 {} 2 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} -7 {} -5 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} -5 {} -5 {} 0 {} -20 {} -20 {} 5 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} 0 {} -10 {} -10 {} 7 {} 5 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -34 {} 0 {} 0 {} 0 {} 0 {} -12 {} -12 {} 0 {} 0 {} 0 {} -37 {} 0 {} -59 {} 0 {} 0 {} 0 {} -61 {} -73 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -308 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -24 {} 0 {} -24 {} -12 {} 0 {} 0 {} 66 {} -37 {} 12 {} 12 {} -12 {} 12 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} -12 {} 24 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 49 {} -49 {} 29 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -50 {} 0 {}
 LangName: 1033 "" "" "Regular" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL" "" "Libertinus Serif" "Semibold"
 GaspTable: 3 8 2 17 1 65535 3 0
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 BeginPrivate: 6
@@ -234,7 +234,7 @@ Grid
  766 430 l 25
 EndSplineSet
 AnchorClass2: "acute"""  "above" "'mark' Mark Positioning lookup 4" "top_punkt" "'mark' Mark Positioning lookup 4" "below" "'mark' Mark Positioning lookup 3" "cedilla" "'mark' Mark Positioning lookup 2" "ogonek" "'mark' Mark Positioning lookup 1" "middle" "'mark' Mark Positioning in Hebrew lookup 0"
-BeginChars: 65810 2359
+BeginChars: 1114386 2359
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -8275,7 +8275,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: Adieresis.alt
-Encoding: 65536 -1 347
+Encoding: 1114112 -1 347
 Width: 699
 GlyphClass: 2
 Flags: MW
@@ -8571,7 +8571,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: Odieresis.alt
-Encoding: 65537 -1 365
+Encoding: 1114113 -1 365
 Width: 730
 GlyphClass: 2
 Flags: MW
@@ -8673,7 +8673,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: Udieresis.alt
-Encoding: 65538 -1 371
+Encoding: 1114114 -1 371
 Width: 678
 GlyphClass: 2
 Flags: MW
@@ -27788,7 +27788,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenleft.sc
-Encoding: 65539 -1 1256
+Encoding: 1114115 -1 1256
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -27806,7 +27806,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenright.sc
-Encoding: 65540 -1 1257
+Encoding: 1114116 -1 1257
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -27824,7 +27824,7 @@ EndSplineSet
 EndChar
 
 StartChar: bracketleft.sc
-Encoding: 65541 -1 1258
+Encoding: 1114117 -1 1258
 Width: 375
 GlyphClass: 2
 Flags: MW
@@ -27844,7 +27844,7 @@ EndSplineSet
 EndChar
 
 StartChar: bracketright.sc
-Encoding: 65542 -1 1259
+Encoding: 1114118 -1 1259
 Width: 375
 GlyphClass: 2
 Flags: MW
@@ -27864,7 +27864,7 @@ EndSplineSet
 EndChar
 
 StartChar: braceleft.sc
-Encoding: 65543 -1 1260
+Encoding: 1114119 -1 1260
 Width: 306
 GlyphClass: 2
 Flags: MW
@@ -27895,7 +27895,7 @@ EndSplineSet
 EndChar
 
 StartChar: braceright.sc
-Encoding: 65544 -1 1261
+Encoding: 1114120 -1 1261
 Width: 306
 GlyphClass: 2
 Flags: MW
@@ -27926,7 +27926,7 @@ EndSplineSet
 EndChar
 
 StartChar: exclamdown.sc
-Encoding: 65545 -1 1262
+Encoding: 1114121 -1 1262
 Width: 244
 GlyphClass: 2
 Flags: MW
@@ -27936,7 +27936,7 @@ Refer: 312 161 N 1 0 0 1 0 216 2
 EndChar
 
 StartChar: questiondown.sc
-Encoding: 65546 -1 1263
+Encoding: 1114122 -1 1263
 Width: 430
 GlyphClass: 2
 Flags: MW
@@ -27946,7 +27946,7 @@ Refer: 342 191 N 1 0 0 1 0 217 2
 EndChar
 
 StartChar: guillemotleft.sc
-Encoding: 65547 -1 1264
+Encoding: 1114123 -1 1264
 Width: 560
 GlyphClass: 2
 Flags: MW
@@ -27956,7 +27956,7 @@ Refer: 322 171 N 1 0 0 1 0 75 2
 EndChar
 
 StartChar: guillemotright.sc
-Encoding: 65548 -1 1265
+Encoding: 1114124 -1 1265
 Width: 560
 GlyphClass: 2
 Flags: MW
@@ -27983,7 +27983,7 @@ EndSplineSet
 EndChar
 
 StartChar: guilsinglleft.sc
-Encoding: 65549 -1 1266
+Encoding: 1114125 -1 1266
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -27993,7 +27993,7 @@ Refer: 1063 8249 N 1 0 0 1 0 73 2
 EndChar
 
 StartChar: guilsinglright.sc
-Encoding: 65550 -1 1267
+Encoding: 1114126 -1 1267
 Width: 355
 GlyphClass: 2
 Flags: MW
@@ -28003,7 +28003,7 @@ Refer: 1064 8250 N 1 0 0 1 0 71 2
 EndChar
 
 StartChar: f_f
-Encoding: 65551 -1 1268
+Encoding: 1114127 -1 1268
 Width: 597
 GlyphClass: 3
 Flags: MW
@@ -28070,7 +28070,7 @@ LCarets2: 1 266
 EndChar
 
 StartChar: f_i
-Encoding: 65552 -1 1269
+Encoding: 1114128 -1 1269
 Width: 580
 GlyphClass: 3
 Flags: MW
@@ -28128,7 +28128,7 @@ LCarets2: 1 297
 EndChar
 
 StartChar: f_l
-Encoding: 65553 -1 1270
+Encoding: 1114129 -1 1270
 Width: 586
 GlyphClass: 3
 Flags: MW
@@ -28189,7 +28189,7 @@ LCarets2: 1 306
 EndChar
 
 StartChar: f_f_i
-Encoding: 65554 -1 1271
+Encoding: 1114130 -1 1271
 Width: 844
 GlyphClass: 3
 Flags: MW
@@ -28269,7 +28269,7 @@ LCarets2: 2 282 566
 EndChar
 
 StartChar: f_f_l
-Encoding: 65555 -1 1272
+Encoding: 1114131 -1 1272
 Width: 847
 GlyphClass: 3
 Flags: MW
@@ -28352,7 +28352,7 @@ LCarets2: 2 268 539
 EndChar
 
 StartChar: longs_t
-Encoding: 65556 -1 1273
+Encoding: 1114132 -1 1273
 Width: 580
 GlyphClass: 3
 Flags: MW
@@ -28364,7 +28364,7 @@ LCarets2: 1 265
 EndChar
 
 StartChar: .notdef
-Encoding: 65557 -1 1274
+Encoding: 1114133 -1 1274
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -31248,7 +31248,7 @@ EndSplineSet
 EndChar
 
 StartChar: Yen.fitted
-Encoding: 65558 -1 1368
+Encoding: 1114134 -1 1368
 Width: 609
 GlyphClass: 2
 Flags: MW
@@ -31349,7 +31349,7 @@ Refer: 682 900 N 1 0 0 1 121 -30 2
 EndChar
 
 StartChar: uniE01F
-Encoding: 65559 -1 1372
+Encoding: 1114135 -1 1372
 Width: 282
 Flags: MW
 LayerCount: 2
@@ -31369,7 +31369,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.oldstyle
-Encoding: 65560 -1 1373
+Encoding: 1114136 -1 1373
 Width: 524
 GlyphClass: 2
 Flags: MW
@@ -31390,7 +31390,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.oldstyle
-Encoding: 65561 -1 1374
+Encoding: 1114137 -1 1374
 Width: 375
 GlyphClass: 2
 Flags: MW
@@ -31661,7 +31661,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE001
-Encoding: 65562 -1 1376
+Encoding: 1114138 -1 1376
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -31715,7 +31715,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE002
-Encoding: 65563 -1 1377
+Encoding: 1114139 -1 1377
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -31769,7 +31769,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE003
-Encoding: 65564 -1 1378
+Encoding: 1114140 -1 1378
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -32067,7 +32067,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE004
-Encoding: 65565 -1 1380
+Encoding: 1114141 -1 1380
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -32270,7 +32270,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE005
-Encoding: 65566 -1 1384
+Encoding: 1114142 -1 1384
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -32295,7 +32295,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE006
-Encoding: 65567 -1 1385
+Encoding: 1114143 -1 1385
 Width: 2341
 Flags: MW
 LayerCount: 2
@@ -32324,7 +32324,7 @@ Refer: 256 46 N 1 0 0 1 1061 209 2
 EndChar
 
 StartChar: uniE007
-Encoding: 65568 -1 1386
+Encoding: 1114144 -1 1386
 Width: 4421
 Flags: MW
 LayerCount: 2
@@ -32353,7 +32353,7 @@ Refer: 256 46 N 1 0 0 1 2108 209 2
 EndChar
 
 StartChar: uniE008
-Encoding: 65569 -1 1387
+Encoding: 1114145 -1 1387
 Width: 6272
 Flags: MW
 LayerCount: 2
@@ -32418,7 +32418,7 @@ EndSplineSet
 EndChar
 
 StartChar: s_t
-Encoding: 65570 -1 1388
+Encoding: 1114146 -1 1388
 Width: 708
 GlyphClass: 3
 Flags: MW
@@ -34209,7 +34209,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.fitted
-Encoding: 65571 -1 1454
+Encoding: 1114147 -1 1454
 Width: 393
 GlyphClass: 2
 Flags: MW
@@ -34219,7 +34219,7 @@ Refer: 10 49 N 1 0 0 1 -32 0 2
 EndChar
 
 StartChar: two.fitted
-Encoding: 65572 -1 1455
+Encoding: 1114148 -1 1455
 Width: 480
 GlyphClass: 2
 Flags: MW
@@ -34229,7 +34229,7 @@ Refer: 11 50 N 1 0 0 1 -6 0 2
 EndChar
 
 StartChar: three.fitted
-Encoding: 65573 -1 1456
+Encoding: 1114149 -1 1456
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -34259,7 +34259,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.fitted
-Encoding: 65574 -1 1457
+Encoding: 1114150 -1 1457
 Width: 505
 GlyphClass: 2
 Flags: MW
@@ -34269,7 +34269,7 @@ Refer: 13 52 N 1 0 0 1 -9 0 2
 EndChar
 
 StartChar: five.fitted
-Encoding: 65575 -1 1458
+Encoding: 1114151 -1 1458
 Width: 472
 GlyphClass: 2
 Flags: MW
@@ -34279,7 +34279,7 @@ Refer: 14 53 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: six.fitted
-Encoding: 65576 -1 1459
+Encoding: 1114152 -1 1459
 Width: 481
 GlyphClass: 2
 Flags: MW
@@ -34289,7 +34289,7 @@ Refer: 15 54 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: two.oldstyle
-Encoding: 65577 -1 1460
+Encoding: 1114153 -1 1460
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -34317,7 +34317,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.oldstyle
-Encoding: 65578 -1 1461
+Encoding: 1114154 -1 1461
 Width: 467
 GlyphClass: 2
 Flags: MW
@@ -42968,7 +42968,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_j
-Encoding: 65579 -1 1792
+Encoding: 1114155 -1 1792
 Width: 563
 GlyphClass: 3
 Flags: MW
@@ -43022,7 +43022,7 @@ LCarets2: 1 296
 EndChar
 
 StartChar: f_t
-Encoding: 65580 -1 1793
+Encoding: 1114156 -1 1793
 Width: 606
 GlyphClass: 3
 Flags: MW
@@ -43078,7 +43078,7 @@ LCarets2: 1 298
 EndChar
 
 StartChar: c_k
-Encoding: 65581 -1 1794
+Encoding: 1114157 -1 1794
 Width: 940
 GlyphClass: 3
 Flags: MW
@@ -43090,7 +43090,7 @@ LCarets2: 1 430
 EndChar
 
 StartChar: c_h
-Encoding: 65582 -1 1795
+Encoding: 1114158 -1 1795
 Width: 958
 GlyphClass: 3
 Flags: MW
@@ -43176,7 +43176,7 @@ Colour: ffffff
 EndChar
 
 StartChar: zero.slash.fitted
-Encoding: 65583 -1 1799
+Encoding: 1114159 -1 1799
 Width: 504
 GlyphClass: 2
 Flags: MW
@@ -43213,7 +43213,7 @@ EndSplineSet
 EndChar
 
 StartChar: Q.u
-Encoding: 65584 -1 1800
+Encoding: 1114160 -1 1800
 Width: 730
 GlyphClass: 2
 Flags: MW
@@ -43248,7 +43248,7 @@ EndSplineSet
 EndChar
 
 StartChar: T_h
-Encoding: 65585 -1 1801
+Encoding: 1114161 -1 1801
 Width: 1126
 GlyphClass: 3
 Flags: MW
@@ -43305,7 +43305,7 @@ LCarets2: 1 472
 EndChar
 
 StartChar: zero.fitted
-Encoding: 65586 -1 1802
+Encoding: 1114162 -1 1802
 Width: 500
 GlyphClass: 2
 Flags: MW
@@ -43326,7 +43326,7 @@ Refer: 254 44 N 1 0 0 1 1 0 2
 EndChar
 
 StartChar: seven.fitted
-Encoding: 65587 -1 1804
+Encoding: 1114163 -1 1804
 Width: 424
 GlyphClass: 2
 Flags: MW
@@ -43336,7 +43336,7 @@ Refer: 16 55 N 1 0 0 1 -32 0 2
 EndChar
 
 StartChar: eight.fitted
-Encoding: 65588 -1 1805
+Encoding: 1114164 -1 1805
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -43346,7 +43346,7 @@ Refer: 2168 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: Euro.fitted
-Encoding: 65589 -1 1806
+Encoding: 1114165 -1 1806
 Width: 615
 GlyphClass: 2
 Flags: MW
@@ -43386,7 +43386,7 @@ EndSplineSet
 EndChar
 
 StartChar: k.sc
-Encoding: 65590 -1 1807
+Encoding: 1114166 -1 1807
 Width: 626
 GlyphClass: 2
 Flags: MW
@@ -43437,7 +43437,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.sc
-Encoding: 65591 -1 1808
+Encoding: 1114167 -1 1808
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -43478,7 +43478,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.sc
-Encoding: 65592 -1 1809
+Encoding: 1114168 -1 1809
 Width: 579
 GlyphClass: 2
 Flags: MW
@@ -43520,7 +43520,7 @@ EndSplineSet
 EndChar
 
 StartChar: c.sc
-Encoding: 65593 -1 1810
+Encoding: 1114169 -1 1810
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -43548,7 +43548,7 @@ EndSplineSet
 EndChar
 
 StartChar: d.sc
-Encoding: 65594 -1 1811
+Encoding: 1114170 -1 1811
 Width: 623
 GlyphClass: 2
 Flags: MW
@@ -43583,7 +43583,7 @@ EndSplineSet
 EndChar
 
 StartChar: e.sc
-Encoding: 65595 -1 1812
+Encoding: 1114171 -1 1812
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -43631,7 +43631,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.sc
-Encoding: 65596 -1 1813
+Encoding: 1114172 -1 1813
 Width: 507
 GlyphClass: 2
 Flags: MW
@@ -43674,7 +43674,7 @@ EndSplineSet
 EndChar
 
 StartChar: g.sc
-Encoding: 65597 -1 1814
+Encoding: 1114173 -1 1814
 Width: 599
 GlyphClass: 2
 Flags: MW
@@ -43709,7 +43709,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.sc
-Encoding: 65598 -1 1815
+Encoding: 1114174 -1 1815
 Width: 704
 GlyphClass: 2
 Flags: MW
@@ -43756,7 +43756,7 @@ EndSplineSet
 EndChar
 
 StartChar: i.sc
-Encoding: 65599 -1 1816
+Encoding: 1114175 -1 1816
 Width: 364
 GlyphClass: 2
 Flags: MW
@@ -43786,7 +43786,7 @@ EndSplineSet
 EndChar
 
 StartChar: j.sc
-Encoding: 65600 -1 1817
+Encoding: 1114176 -1 1817
 Width: 374
 GlyphClass: 2
 Flags: MW
@@ -43815,7 +43815,7 @@ EndSplineSet
 EndChar
 
 StartChar: l.sc
-Encoding: 65601 -1 1818
+Encoding: 1114177 -1 1818
 Width: 517
 GlyphClass: 2
 Flags: MW
@@ -43850,7 +43850,7 @@ EndSplineSet
 EndChar
 
 StartChar: m.sc
-Encoding: 65602 -1 1819
+Encoding: 1114178 -1 1819
 Width: 697
 GlyphClass: 2
 Flags: MW
@@ -43897,7 +43897,7 @@ EndSplineSet
 EndChar
 
 StartChar: n.sc
-Encoding: 65603 -1 1820
+Encoding: 1114179 -1 1820
 Width: 622
 GlyphClass: 2
 Flags: MW
@@ -43940,7 +43940,7 @@ EndSplineSet
 EndChar
 
 StartChar: o.sc
-Encoding: 65604 -1 1821
+Encoding: 1114180 -1 1821
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -43966,7 +43966,7 @@ EndSplineSet
 EndChar
 
 StartChar: p.sc
-Encoding: 65605 -1 1822
+Encoding: 1114181 -1 1822
 Width: 540
 GlyphClass: 2
 Flags: MW
@@ -44003,7 +44003,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.sc
-Encoding: 65606 -1 1823
+Encoding: 1114182 -1 1823
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44038,7 +44038,7 @@ EndSplineSet
 EndChar
 
 StartChar: r.sc
-Encoding: 65607 -1 1824
+Encoding: 1114183 -1 1824
 Width: 588
 GlyphClass: 2
 Flags: MW
@@ -44081,7 +44081,7 @@ EndSplineSet
 EndChar
 
 StartChar: s.sc
-Encoding: 65608 -1 1825
+Encoding: 1114184 -1 1825
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -44115,7 +44115,7 @@ EndSplineSet
 EndChar
 
 StartChar: t.sc
-Encoding: 65609 -1 1826
+Encoding: 1114185 -1 1826
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -44152,7 +44152,7 @@ EndSplineSet
 EndChar
 
 StartChar: u.sc
-Encoding: 65610 -1 1827
+Encoding: 1114186 -1 1827
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -44189,7 +44189,7 @@ EndSplineSet
 EndChar
 
 StartChar: v.sc
-Encoding: 65611 -1 1828
+Encoding: 1114187 -1 1828
 Width: 550
 GlyphClass: 2
 Flags: MW
@@ -44223,7 +44223,7 @@ EndSplineSet
 EndChar
 
 StartChar: w.sc
-Encoding: 65612 -1 1829
+Encoding: 1114188 -1 1829
 Width: 790
 GlyphClass: 2
 Flags: MW
@@ -44268,7 +44268,7 @@ EndSplineSet
 EndChar
 
 StartChar: x.sc
-Encoding: 65613 -1 1830
+Encoding: 1114189 -1 1830
 Width: 561
 GlyphClass: 2
 Flags: MW
@@ -44319,7 +44319,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.sc
-Encoding: 65614 -1 1831
+Encoding: 1114190 -1 1831
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44362,7 +44362,7 @@ EndSplineSet
 EndChar
 
 StartChar: z.sc
-Encoding: 65615 -1 1832
+Encoding: 1114191 -1 1832
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -44400,7 +44400,7 @@ EndSplineSet
 EndChar
 
 StartChar: agrave.sc
-Encoding: 65616 -1 1833
+Encoding: 1114192 -1 1833
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44411,7 +44411,7 @@ Refer: 669 768 N 1 0 0 1 448 -36 2
 EndChar
 
 StartChar: aacute.sc
-Encoding: 65617 -1 1834
+Encoding: 1114193 -1 1834
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44422,7 +44422,7 @@ Refer: 670 769 N 1 0 0 1 456 -42 2
 EndChar
 
 StartChar: acircumflex.sc
-Encoding: 65618 -1 1835
+Encoding: 1114194 -1 1835
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44433,7 +44433,7 @@ Refer: 671 770 N 1 0 0 1 427 -46 2
 EndChar
 
 StartChar: atilde.sc
-Encoding: 65619 -1 1836
+Encoding: 1114195 -1 1836
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44444,7 +44444,7 @@ Refer: 672 771 N 1 0 0 1 438 -47 2
 EndChar
 
 StartChar: adieresis.sc
-Encoding: 65620 -1 1837
+Encoding: 1114196 -1 1837
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44455,7 +44455,7 @@ Refer: 674 776 N 1 0 0 1 485 -2 2
 EndChar
 
 StartChar: aring.sc
-Encoding: 65621 -1 1838
+Encoding: 1114197 -1 1838
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -44466,7 +44466,7 @@ Refer: 1413 778 N 1 0 0 1 469 -72 2
 EndChar
 
 StartChar: ae.sc
-Encoding: 65622 -1 1839
+Encoding: 1114198 -1 1839
 Width: 824
 GlyphClass: 2
 Flags: MW
@@ -44525,7 +44525,7 @@ EndSplineSet
 EndChar
 
 StartChar: ccedilla.sc
-Encoding: 65623 -1 1840
+Encoding: 1114199 -1 1840
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -44561,7 +44561,7 @@ EndSplineSet
 EndChar
 
 StartChar: egrave.sc
-Encoding: 65624 -1 1841
+Encoding: 1114200 -1 1841
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -44606,7 +44606,7 @@ Refer: 669 768 N 1 0 0 1 405 0 2
 EndChar
 
 StartChar: eacute.sc
-Encoding: 65625 -1 1842
+Encoding: 1114201 -1 1842
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -44651,7 +44651,7 @@ Refer: 670 769 N 1 0 0 1 461 0 2
 EndChar
 
 StartChar: ecircumflex.sc
-Encoding: 65626 -1 1843
+Encoding: 1114202 -1 1843
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -44696,7 +44696,7 @@ Refer: 671 770 N 1 0 0 1 434 -29 2
 EndChar
 
 StartChar: edieresis.sc
-Encoding: 65627 -1 1844
+Encoding: 1114203 -1 1844
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -44741,7 +44741,7 @@ Refer: 674 776 N 1 0 0 1 493 0 2
 EndChar
 
 StartChar: igrave.sc
-Encoding: 65628 -1 1845
+Encoding: 1114204 -1 1845
 Width: 364
 GlyphClass: 2
 Flags: MW
@@ -44752,7 +44752,7 @@ Refer: 669 768 N 1 0 0 1 268 -43 2
 EndChar
 
 StartChar: iacute.sc
-Encoding: 65629 -1 1846
+Encoding: 1114205 -1 1846
 Width: 364
 GlyphClass: 2
 Flags: MW
@@ -44763,7 +44763,7 @@ Refer: 670 769 N 1 0 0 1 325 -45 2
 EndChar
 
 StartChar: icircumflex.sc
-Encoding: 65630 -1 1847
+Encoding: 1114206 -1 1847
 Width: 364
 GlyphClass: 2
 Flags: MW
@@ -44774,7 +44774,7 @@ Refer: 671 770 N 1 0 0 1 280 -46 2
 EndChar
 
 StartChar: idieresis.sc
-Encoding: 65631 -1 1848
+Encoding: 1114207 -1 1848
 Width: 364
 GlyphClass: 2
 Flags: MW
@@ -44785,7 +44785,7 @@ Refer: 674 776 N 1 0 0 1 333 -1 2
 EndChar
 
 StartChar: eth.sc
-Encoding: 65632 -1 1849
+Encoding: 1114208 -1 1849
 Width: 623
 GlyphClass: 2
 Flags: MW
@@ -44823,7 +44823,7 @@ EndSplineSet
 EndChar
 
 StartChar: ntilde.sc
-Encoding: 65633 -1 1850
+Encoding: 1114209 -1 1850
 Width: 622
 GlyphClass: 2
 Flags: MW
@@ -44834,7 +44834,7 @@ Refer: 672 771 N 1 0 0 1 459 -47 2
 EndChar
 
 StartChar: ograve.sc
-Encoding: 65634 -1 1851
+Encoding: 1114210 -1 1851
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44845,7 +44845,7 @@ Refer: 669 768 N 1 0 0 1 421 0 2
 EndChar
 
 StartChar: oacute.sc
-Encoding: 65635 -1 1852
+Encoding: 1114211 -1 1852
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44856,7 +44856,7 @@ Refer: 670 769 N 1 0 0 1 461 0 2
 EndChar
 
 StartChar: ocircumflex.sc
-Encoding: 65636 -1 1853
+Encoding: 1114212 -1 1853
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44867,7 +44867,7 @@ Refer: 671 770 N 1 0 0 1 423 -29 2
 EndChar
 
 StartChar: otilde.sc
-Encoding: 65637 -1 1854
+Encoding: 1114213 -1 1854
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44878,7 +44878,7 @@ Refer: 672 771 N 1 0 0 1 423 0 2
 EndChar
 
 StartChar: odieresis.sc
-Encoding: 65638 -1 1855
+Encoding: 1114214 -1 1855
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44889,7 +44889,7 @@ Refer: 674 776 N 1 0 0 1 479 -2 2
 EndChar
 
 StartChar: oe.sc
-Encoding: 65639 -1 1856
+Encoding: 1114215 -1 1856
 Width: 856
 GlyphClass: 2
 Flags: MW
@@ -44937,7 +44937,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslash.sc
-Encoding: 65640 -1 1857
+Encoding: 1114216 -1 1857
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -44971,7 +44971,7 @@ EndSplineSet
 EndChar
 
 StartChar: ugrave.sc
-Encoding: 65641 -1 1858
+Encoding: 1114217 -1 1858
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -44982,7 +44982,7 @@ Refer: 669 768 N 1 0 0 1 424 -40 2
 EndChar
 
 StartChar: uacute.sc
-Encoding: 65642 -1 1859
+Encoding: 1114218 -1 1859
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -44993,7 +44993,7 @@ Refer: 670 769 N 1 0 0 1 495 -45 2
 EndChar
 
 StartChar: ucircumflex.sc
-Encoding: 65643 -1 1860
+Encoding: 1114219 -1 1860
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -45004,7 +45004,7 @@ Refer: 671 770 N 1 0 0 1 437 -51 2
 EndChar
 
 StartChar: udieresis.sc
-Encoding: 65644 -1 1861
+Encoding: 1114220 -1 1861
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -45015,7 +45015,7 @@ Refer: 674 776 N 1 0 0 1 510 0 2
 EndChar
 
 StartChar: yacute.sc
-Encoding: 65645 -1 1862
+Encoding: 1114221 -1 1862
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -45026,7 +45026,7 @@ Refer: 670 769 N 1 0 0 1 452 -39 2
 EndChar
 
 StartChar: thorn.sc
-Encoding: 65646 -1 1863
+Encoding: 1114222 -1 1863
 Width: 529
 GlyphClass: 2
 Flags: MW
@@ -45061,7 +45061,7 @@ EndSplineSet
 EndChar
 
 StartChar: ydieresis.sc
-Encoding: 65647 -1 1864
+Encoding: 1114223 -1 1864
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -45072,7 +45072,7 @@ Refer: 674 776 N 1 0 0 1 486 0 2
 EndChar
 
 StartChar: ij.sc
-Encoding: 65648 -1 1865
+Encoding: 1114224 -1 1865
 Width: 719
 GlyphClass: 2
 Flags: MW
@@ -45083,7 +45083,7 @@ Refer: 1816 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: germandbls.scalt
-Encoding: 65649 -1 1866
+Encoding: 1114225 -1 1866
 Width: 769
 GlyphClass: 2
 Flags: MW
@@ -45094,7 +45094,7 @@ Refer: 1825 -1 N 1 0 0 1 386 0 2
 EndChar
 
 StartChar: hyphen.sc
-Encoding: 65650 -1 1867
+Encoding: 1114226 -1 1867
 Width: 358
 GlyphClass: 2
 Flags: MW
@@ -45104,7 +45104,7 @@ Refer: 255 45 N 1 0 0 1 0 -19 2
 EndChar
 
 StartChar: ampersand.alt
-Encoding: 65651 -1 1868
+Encoding: 1114227 -1 1868
 Width: 740
 GlyphClass: 2
 Flags: MW
@@ -55140,7 +55140,7 @@ EndSplineSet
 EndChar
 
 StartChar: abreve.sc
-Encoding: 65652 -1 2139
+Encoding: 1114228 -1 2139
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -55151,7 +55151,7 @@ Refer: 1417 774 N 1 0 0 1 449 -16 2
 EndChar
 
 StartChar: aogonek.sc
-Encoding: 65653 -1 2140
+Encoding: 1114229 -1 2140
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -55195,7 +55195,7 @@ EndSplineSet
 EndChar
 
 StartChar: cacute.sc
-Encoding: 65654 -1 2141
+Encoding: 1114230 -1 2141
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -55219,7 +55219,7 @@ Refer: 670 769 N 1 0 0 1 435 -34 2
 EndChar
 
 StartChar: ccaron.sc
-Encoding: 65655 -1 2142
+Encoding: 1114231 -1 2142
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -55243,7 +55243,7 @@ Refer: 676 780 N 1 0 0 1 474 -20 2
 EndChar
 
 StartChar: dcaron.sc
-Encoding: 65656 -1 2143
+Encoding: 1114232 -1 2143
 Width: 623
 GlyphClass: 2
 Flags: MW
@@ -55254,7 +55254,7 @@ Refer: 676 780 N 1 0 0 1 475 -20 2
 EndChar
 
 StartChar: eogonek.sc
-Encoding: 65657 -1 2144
+Encoding: 1114233 -1 2144
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -55309,7 +55309,7 @@ EndSplineSet
 EndChar
 
 StartChar: ecaron.sc
-Encoding: 65658 -1 2145
+Encoding: 1114234 -1 2145
 Width: 564
 GlyphClass: 2
 Flags: MW
@@ -55354,7 +55354,7 @@ Refer: 676 780 N 1 0 0 1 491 -15 2
 EndChar
 
 StartChar: gbreve.sc
-Encoding: 65659 -1 2146
+Encoding: 1114235 -1 2146
 Width: 599
 GlyphClass: 2
 Flags: MW
@@ -55365,7 +55365,7 @@ Refer: 1417 774 N 1 0 0 1 449 0 2
 EndChar
 
 StartChar: lacute.sc
-Encoding: 65660 -1 2147
+Encoding: 1114236 -1 2147
 Width: 517
 GlyphClass: 2
 Flags: MW
@@ -55376,7 +55376,7 @@ Refer: 670 769 N 1 0 0 1 360 -38 2
 EndChar
 
 StartChar: lslash.sc
-Encoding: 65661 -1 2148
+Encoding: 1114237 -1 2148
 Width: 517
 GlyphClass: 2
 Flags: MW
@@ -55414,7 +55414,7 @@ EndSplineSet
 EndChar
 
 StartChar: nacute.sc
-Encoding: 65662 -1 2149
+Encoding: 1114238 -1 2149
 Width: 622
 GlyphClass: 2
 Flags: MW
@@ -55425,7 +55425,7 @@ Refer: 670 769 N 1 0 0 1 530 -37 2
 EndChar
 
 StartChar: ncaron.sc
-Encoding: 65663 -1 2150
+Encoding: 1114239 -1 2150
 Width: 622
 GlyphClass: 2
 Flags: MW
@@ -55436,7 +55436,7 @@ Refer: 676 780 N 1 0 0 1 510 -24 2
 EndChar
 
 StartChar: eng.sc
-Encoding: 65664 -1 2151
+Encoding: 1114240 -1 2151
 Width: 603
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
@@ -55479,7 +55479,7 @@ EndSplineSet
 EndChar
 
 StartChar: ohungarumlaut.sc
-Encoding: 65665 -1 2152
+Encoding: 1114241 -1 2152
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -55490,7 +55490,7 @@ Refer: 1414 779 N 1 0 0 1 474 -48 2
 EndChar
 
 StartChar: racute.sc
-Encoding: 65666 -1 2153
+Encoding: 1114242 -1 2153
 Width: 588
 GlyphClass: 2
 Flags: MW
@@ -55501,7 +55501,7 @@ Refer: 670 769 N 1 0 0 1 478 -38 2
 EndChar
 
 StartChar: rcaron.sc
-Encoding: 65667 -1 2154
+Encoding: 1114243 -1 2154
 Width: 588
 GlyphClass: 2
 Flags: MW
@@ -55512,7 +55512,7 @@ Refer: 676 780 N 1 0 0 1 436 -24 2
 EndChar
 
 StartChar: sacute.sc
-Encoding: 65668 -1 2155
+Encoding: 1114244 -1 2155
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -55523,7 +55523,7 @@ Refer: 670 769 N 1 0 0 1 383 -38 2
 EndChar
 
 StartChar: scedilla.sc
-Encoding: 65669 -1 2156
+Encoding: 1114245 -1 2156
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -55566,7 +55566,7 @@ EndSplineSet
 EndChar
 
 StartChar: scaron.sc
-Encoding: 65670 -1 2157
+Encoding: 1114246 -1 2157
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -55577,7 +55577,7 @@ Refer: 676 780 N 1 0 0 1 418 -15 2
 EndChar
 
 StartChar: uni0163.sc
-Encoding: 65671 -1 2158
+Encoding: 1114247 -1 2158
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -55622,7 +55622,7 @@ EndSplineSet
 EndChar
 
 StartChar: tbar.sc
-Encoding: 65672 -1 2159
+Encoding: 1114248 -1 2159
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -55663,7 +55663,7 @@ EndSplineSet
 EndChar
 
 StartChar: uring.sc
-Encoding: 65673 -1 2160
+Encoding: 1114249 -1 2160
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -55674,7 +55674,7 @@ Refer: 1413 778 N 1 0 0 1 482 -61 2
 EndChar
 
 StartChar: uhungarumlaut.sc
-Encoding: 65674 -1 2161
+Encoding: 1114250 -1 2161
 Width: 594
 GlyphClass: 2
 Flags: MW
@@ -55685,7 +55685,7 @@ Refer: 1414 779 N 1 0 0 1 515 -48 2
 EndChar
 
 StartChar: zacute.sc
-Encoding: 65675 -1 2162
+Encoding: 1114251 -1 2162
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -55696,7 +55696,7 @@ Refer: 670 769 N 1 0 0 1 405 -34 2
 EndChar
 
 StartChar: zdotaccent.sc
-Encoding: 65676 -1 2163
+Encoding: 1114252 -1 2163
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -55707,7 +55707,7 @@ Refer: 673 775 N 1 0 0 1 420 36 2
 EndChar
 
 StartChar: zcaron.sc
-Encoding: 65677 -1 2164
+Encoding: 1114253 -1 2164
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -55718,7 +55718,7 @@ Refer: 676 780 N 1 0 0 1 444 -15 2
 EndChar
 
 StartChar: lcaron.sc
-Encoding: 65678 -1 2165
+Encoding: 1114254 -1 2165
 Width: 517
 GlyphClass: 2
 Flags: MW
@@ -55729,7 +55729,7 @@ Refer: 655 700 N 1 0 0 1 344 -102 2
 EndChar
 
 StartChar: dcroat.sc
-Encoding: 65679 -1 2166
+Encoding: 1114255 -1 2166
 Width: 623
 GlyphClass: 2
 Flags: MW
@@ -55739,7 +55739,7 @@ Refer: 1849 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: tcaron.sc
-Encoding: 65680 -1 2167
+Encoding: 1114256 -1 2167
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -56486,7 +56486,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.superior
-Encoding: 65681 -1 2190
+Encoding: 1114257 -1 2190
 Width: 324
 GlyphClass: 2
 Flags: MW
@@ -56740,7 +56740,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: germandbls.sc
-Encoding: 65682 -1 2196
+Encoding: 1114258 -1 2196
 Width: 595
 GlyphClass: 2
 Flags: MW
@@ -56786,7 +56786,7 @@ EndSplineSet
 EndChar
 
 StartChar: t_z
-Encoding: 65683 -1 2197
+Encoding: 1114259 -1 2197
 Width: 549
 GlyphClass: 3
 Flags: MW
@@ -56838,7 +56838,7 @@ Refer: 321 170 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE100
-Encoding: 65684 -1 2199
+Encoding: 1114260 -1 2199
 Width: 633
 Flags: MW
 LayerCount: 2
@@ -56858,7 +56858,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.oldstyle
-Encoding: 65685 -1 2200
+Encoding: 1114261 -1 2200
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -56868,7 +56868,7 @@ Refer: 13 52 N 1 0 0 1 0 -169 2
 EndChar
 
 StartChar: five.oldstyle
-Encoding: 65686 -1 2201
+Encoding: 1114262 -1 2201
 Width: 437
 GlyphClass: 2
 Flags: MW
@@ -56878,7 +56878,7 @@ Refer: 14 53 N 1 0 0 1 -20 -167 2
 EndChar
 
 StartChar: six.oldstyle
-Encoding: 65687 -1 2202
+Encoding: 1114263 -1 2202
 Width: 472
 GlyphClass: 2
 Flags: MW
@@ -56888,7 +56888,7 @@ Refer: 15 54 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: seven.oldstyle
-Encoding: 65688 -1 2203
+Encoding: 1114264 -1 2203
 Width: 421
 GlyphClass: 2
 Flags: MW
@@ -56898,7 +56898,7 @@ Refer: 16 55 N 1 0 0 1 -35 -158 2
 EndChar
 
 StartChar: nine.oldstyle
-Encoding: 65689 -1 2204
+Encoding: 1114265 -1 2204
 Width: 468
 GlyphClass: 2
 Flags: MW
@@ -56908,7 +56908,7 @@ Refer: 17 57 N 1 0 0 1 -10.5 -166 2
 EndChar
 
 StartChar: uniE0F9
-Encoding: 65690 -1 2205
+Encoding: 1114266 -1 2205
 Width: 623
 Flags: MW
 LayerCount: 2
@@ -56919,7 +56919,7 @@ Refer: 1053 8219 N 1 0 0 1 378 2 2
 EndChar
 
 StartChar: c_t
-Encoding: 65691 -1 2206
+Encoding: 1114267 -1 2206
 Width: 743
 GlyphClass: 3
 Flags: MW
@@ -56970,7 +56970,7 @@ LCarets2: 1 422
 EndChar
 
 StartChar: h.alt
-Encoding: 65692 -1 2207
+Encoding: 1114268 -1 2207
 Width: 580
 GlyphClass: 2
 Flags: MW
@@ -57058,7 +57058,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.taboldstyle
-Encoding: 65693 -1 2210
+Encoding: 1114269 -1 2210
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57079,7 +57079,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.taboldstyle
-Encoding: 65694 -1 2211
+Encoding: 1114270 -1 2211
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57089,7 +57089,7 @@ Refer: 1374 -1 N 1 0 0 1 47 0 2
 EndChar
 
 StartChar: two.taboldstyle
-Encoding: 65695 -1 2212
+Encoding: 1114271 -1 2212
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57117,7 +57117,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.taboldstyle
-Encoding: 65696 -1 2213
+Encoding: 1114272 -1 2213
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57127,7 +57127,7 @@ Refer: 1456 -1 N 1 0 0 1 4 -166 2
 EndChar
 
 StartChar: four.taboldstyle
-Encoding: 65697 -1 2214
+Encoding: 1114273 -1 2214
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57137,7 +57137,7 @@ Refer: 13 52 N 1 0 0 1 -8 -169 2
 EndChar
 
 StartChar: five.taboldstyle
-Encoding: 65698 -1 2215
+Encoding: 1114274 -1 2215
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57147,7 +57147,7 @@ Refer: 14 53 N 1 0 0 1 -7 -167 2
 EndChar
 
 StartChar: six.taboldstyle
-Encoding: 65699 -1 2216
+Encoding: 1114275 -1 2216
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57157,7 +57157,7 @@ Refer: 15 54 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: seven.taboldstyle
-Encoding: 65700 -1 2217
+Encoding: 1114276 -1 2217
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57167,7 +57167,7 @@ Refer: 16 55 N 1 0 0 1 -4 -158 2
 EndChar
 
 StartChar: nine.taboldstyle
-Encoding: 65701 -1 2218
+Encoding: 1114277 -1 2218
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57219,7 +57219,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE0FB
-Encoding: 65702 -1 2220
+Encoding: 1114278 -1 2220
 Width: 640
 Flags: MW
 LayerCount: 2
@@ -57230,7 +57230,7 @@ Refer: 254 44 N 1 0 0 1 401 603 2
 EndChar
 
 StartChar: uniE104
-Encoding: 65703 -1 2221
+Encoding: 1114279 -1 2221
 Width: 611
 Flags: MW
 LayerCount: 2
@@ -57327,7 +57327,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE105
-Encoding: 65704 -1 2222
+Encoding: 1114280 -1 2222
 Width: 835
 Flags: MW
 LayerCount: 2
@@ -57467,7 +57467,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE106
-Encoding: 65705 -1 2223
+Encoding: 1114281 -1 2223
 Width: 730
 UnlinkRmOvrlpSave: 1
 Flags: MW
@@ -57530,7 +57530,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE107
-Encoding: 65706 -1 2224
+Encoding: 1114282 -1 2224
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -57611,7 +57611,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.fitted
-Encoding: 65707 -1 2225
+Encoding: 1114283 -1 2225
 Width: 485
 GlyphClass: 2
 Flags: MW
@@ -57621,7 +57621,7 @@ Refer: 17 57 N 1 0 0 1 -1 0 2
 EndChar
 
 StartChar: eight.taboldstyle
-Encoding: 65708 -1 2226
+Encoding: 1114284 -1 2226
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57631,7 +57631,7 @@ Refer: 2168 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: eight.oldstyle
-Encoding: 65709 -1 2227
+Encoding: 1114285 -1 2227
 Width: 490
 Flags: MW
 LayerCount: 2
@@ -57640,7 +57640,7 @@ Refer: 2168 56 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.slash
-Encoding: 65710 -1 2228
+Encoding: 1114286 -1 2228
 Width: 490
 GlyphClass: 2
 Flags: MW
@@ -57677,7 +57677,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.alt
-Encoding: 65711 -1 2229
+Encoding: 1114287 -1 2229
 Width: 600
 GlyphClass: 2
 Flags: MW
@@ -57724,7 +57724,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.ss03
-Encoding: 65712 -1 2230
+Encoding: 1114288 -1 2230
 Width: 746
 GlyphClass: 2
 Flags: MW
@@ -57735,7 +57735,7 @@ Refer: 1981 115 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni1E9E.alt
-Encoding: 65713 -1 2231
+Encoding: 1114289 -1 2231
 Width: 947
 GlyphClass: 2
 Flags: MW
@@ -57746,7 +57746,7 @@ Refer: 268 83 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE00B
-Encoding: 65714 -1 2232
+Encoding: 1114290 -1 2232
 Width: 407
 Flags: MW
 LayerCount: 2
@@ -58032,7 +58032,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni021B.sc
-Encoding: 65715 -1 2239
+Encoding: 1114291 -1 2239
 Width: 552
 GlyphClass: 2
 Flags: MW
@@ -58043,7 +58043,7 @@ Refer: 680 806 N 1 0 0 1 550 -21 2
 EndChar
 
 StartChar: uni0219.sc
-Encoding: 65716 -1 2240
+Encoding: 1114292 -1 2240
 Width: 427
 GlyphClass: 2
 Flags: MW
@@ -58054,7 +58054,7 @@ Refer: 680 806 N 1 0 0 1 436 -21 2
 EndChar
 
 StartChar: idotaccent.sc
-Encoding: 65717 -1 2241
+Encoding: 1114293 -1 2241
 Width: 364
 GlyphClass: 2
 Flags: MW
@@ -58065,7 +58065,7 @@ Refer: 673 775 N 1 0 0 1 348 0 2
 EndChar
 
 StartChar: b.inferior
-Encoding: 65718 -1 2242
+Encoding: 1114294 -1 2242
 Width: 297
 GlyphClass: 2
 Flags: MW
@@ -58075,7 +58075,7 @@ Refer: 2180 7495 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: c.inferior
-Encoding: 65719 -1 2243
+Encoding: 1114295 -1 2243
 Width: 332
 GlyphClass: 2
 Flags: MW
@@ -58085,7 +58085,7 @@ Refer: 2181 7580 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: d.inferior
-Encoding: 65720 -1 2244
+Encoding: 1114296 -1 2244
 Width: 332
 GlyphClass: 2
 Flags: MW
@@ -58095,7 +58095,7 @@ Refer: 2182 7496 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: f.inferior
-Encoding: 65721 -1 2245
+Encoding: 1114297 -1 2245
 Width: 332
 GlyphClass: 2
 Flags: MW
@@ -58105,7 +58105,7 @@ Refer: 2184 7584 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: g.inferior
-Encoding: 65722 -1 2246
+Encoding: 1114298 -1 2246
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -58115,7 +58115,7 @@ Refer: 2185 7501 N 1 0 0 1 0 -474 2
 EndChar
 
 StartChar: h.inferior
-Encoding: 65723 -1 2247
+Encoding: 1114299 -1 2247
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -58125,7 +58125,7 @@ Refer: 1389 688 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: i.inferior
-Encoding: 65724 -1 2248
+Encoding: 1114300 -1 2248
 Width: 218
 GlyphClass: 2
 Flags: MW
@@ -58135,7 +58135,7 @@ Refer: 1072 8305 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: j.inferior
-Encoding: 65725 -1 2249
+Encoding: 1114301 -1 2249
 Width: 207
 GlyphClass: 2
 Flags: MW
@@ -58145,7 +58145,7 @@ Refer: 1390 690 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: k.inferior
-Encoding: 65726 -1 2250
+Encoding: 1114302 -1 2250
 Width: 332
 GlyphClass: 2
 Flags: MW
@@ -58155,7 +58155,7 @@ Refer: 2186 7503 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: l.inferior
-Encoding: 65727 -1 2251
+Encoding: 1114303 -1 2251
 Width: 161
 GlyphClass: 2
 Flags: MW
@@ -58165,7 +58165,7 @@ Refer: 292 737 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: m.inferior
-Encoding: 65728 -1 2252
+Encoding: 1114304 -1 2252
 Width: 485
 GlyphClass: 2
 Flags: MW
@@ -58175,7 +58175,7 @@ Refer: 2187 7504 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: n.inferior
-Encoding: 65729 -1 2253
+Encoding: 1114305 -1 2253
 Width: 332
 GlyphClass: 2
 Flags: MW
@@ -58185,7 +58185,7 @@ Refer: 1084 8319 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: p.inferior
-Encoding: 65730 -1 2254
+Encoding: 1114306 -1 2254
 Width: 305
 GlyphClass: 2
 Flags: MW
@@ -58195,7 +58195,7 @@ Refer: 2189 7510 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: q.inferior
-Encoding: 65731 -1 2255
+Encoding: 1114307 -1 2255
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -58205,7 +58205,7 @@ Refer: 2190 -1 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: r.inferior
-Encoding: 65732 -1 2256
+Encoding: 1114308 -1 2256
 Width: 246
 GlyphClass: 2
 Flags: MW
@@ -58215,7 +58215,7 @@ Refer: 1391 691 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: s.inferior
-Encoding: 65733 -1 2257
+Encoding: 1114309 -1 2257
 Width: 253
 GlyphClass: 2
 Flags: MW
@@ -58225,7 +58225,7 @@ Refer: 299 738 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: t.inferior
-Encoding: 65734 -1 2258
+Encoding: 1114310 -1 2258
 Width: 228
 GlyphClass: 2
 Flags: MW
@@ -58235,7 +58235,7 @@ Refer: 2191 7511 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: u.inferior
-Encoding: 65735 -1 2259
+Encoding: 1114311 -1 2259
 Width: 329
 GlyphClass: 2
 Flags: MW
@@ -58245,7 +58245,7 @@ Refer: 2192 7512 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: v.inferior
-Encoding: 65736 -1 2260
+Encoding: 1114312 -1 2260
 Width: 334
 GlyphClass: 2
 Flags: MW
@@ -58255,7 +58255,7 @@ Refer: 2193 7515 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: w.inferior
-Encoding: 65737 -1 2261
+Encoding: 1114313 -1 2261
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -58265,7 +58265,7 @@ Refer: 1393 695 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: y.inferior
-Encoding: 65738 -1 2262
+Encoding: 1114314 -1 2262
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -58275,7 +58275,7 @@ Refer: 1394 696 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: z.inferior
-Encoding: 65739 -1 2263
+Encoding: 1114315 -1 2263
 Width: 294
 GlyphClass: 2
 Flags: MW
@@ -58285,7 +58285,7 @@ Refer: 2194 7611 N 1 0 0 1 0 -476 2
 EndChar
 
 StartChar: hyphen.cap
-Encoding: 65740 -1 2264
+Encoding: 1114316 -1 2264
 Width: 358
 GlyphClass: 2
 Flags: MW
@@ -58295,7 +58295,7 @@ Refer: 255 45 N 1 0 0 1 0 60 2
 EndChar
 
 StartChar: uniE130
-Encoding: 65741 -1 2265
+Encoding: 1114317 -1 2265
 Width: 179
 Flags: MW
 LayerCount: 2
@@ -58398,7 +58398,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyrcap
-Encoding: 65742 -1 2268
+Encoding: 1114318 -1 2268
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58409,7 +58409,7 @@ Refer: 1796 864 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breve.cyr
-Encoding: 65743 -1 2269
+Encoding: 1114319 -1 2269
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58419,7 +58419,7 @@ Refer: 1797 865 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: dieresis.cap
-Encoding: 65744 -1 2270
+Encoding: 1114320 -1 2270
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58430,7 +58430,7 @@ Refer: 1798 866 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: hookabovecomb.cap
-Encoding: 65745 -1 2271
+Encoding: 1114321 -1 2271
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58441,7 +58441,7 @@ Refer: 2138 867 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: dotaccent.cap
-Encoding: 65746 -1 2272
+Encoding: 1114322 -1 2272
 Width: 291
 GlyphClass: 4
 Flags: MW
@@ -58452,7 +58452,7 @@ Refer: 673 775 N 1 0 0 1 315 155 2
 EndChar
 
 StartChar: grave.cap
-Encoding: 65747 -1 2273
+Encoding: 1114323 -1 2273
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58463,7 +58463,7 @@ Refer: 1679 856 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: acute.cap
-Encoding: 65748 -1 2274
+Encoding: 1114324 -1 2274
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58474,7 +58474,7 @@ Refer: 1681 857 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: circumflex.cap
-Encoding: 65749 -1 2275
+Encoding: 1114325 -1 2275
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58485,7 +58485,7 @@ Refer: 1680 858 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: caron.cap
-Encoding: 65750 -1 2276
+Encoding: 1114326 -1 2276
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58496,7 +58496,7 @@ Refer: 1733 859 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breve.cap
-Encoding: 65751 -1 2277
+Encoding: 1114327 -1 2277
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58507,7 +58507,7 @@ Refer: 1734 860 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: hungarumlaut.cap
-Encoding: 65752 -1 2278
+Encoding: 1114328 -1 2278
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58518,7 +58518,7 @@ Refer: 1735 861 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni030F.cap
-Encoding: 65753 -1 2279
+Encoding: 1114329 -1 2279
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58529,7 +58529,7 @@ Refer: 1736 862 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: breveinvertedcmb.cap
-Encoding: 65754 -1 2280
+Encoding: 1114330 -1 2280
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -58540,7 +58540,7 @@ Refer: 1737 863 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: q.sc.u
-Encoding: 65755 -1 2281
+Encoding: 1114331 -1 2281
 Width: 589
 GlyphClass: 2
 Flags: MW
@@ -58638,7 +58638,7 @@ EndSplineSet
 EndChar
 
 StartChar: aeacute.sc
-Encoding: 65756 -1 2283
+Encoding: 1114332 -1 2283
 Width: 824
 VWidth: 0
 GlyphClass: 2
@@ -58649,7 +58649,7 @@ Refer: 1839 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni01E3.sc
-Encoding: 65757 -1 2284
+Encoding: 1114333 -1 2284
 Width: 824
 VWidth: 0
 GlyphClass: 2
@@ -58660,7 +58660,7 @@ Refer: 1839 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65758 -1 2285
+Encoding: 1114334 -1 2285
 Width: 710
 GlyphClass: 2
 Flags: W
@@ -58717,7 +58717,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle.sc
-Encoding: 65759 -1 2286
+Encoding: 1114335 -1 2286
 Width: 614
 GlyphClass: 2
 Flags: W
@@ -58775,7 +58775,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.short
-Encoding: 65760 -1 2287
+Encoding: 1114336 -1 2287
 Width: 336
 GlyphClass: 2
 Flags: W
@@ -58820,7 +58820,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f.short
-Encoding: 65761 -1 2288
+Encoding: 1114337 -1 2288
 Width: 597
 GlyphClass: 3
 Flags: W
@@ -58886,7 +58886,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f_j
-Encoding: 65762 -1 2289
+Encoding: 1114338 -1 2289
 Width: 844
 GlyphClass: 3
 Flags: W
@@ -58962,7 +58962,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_i
-Encoding: 65763 -1 2290
+Encoding: 1114339 -1 2290
 Width: 580
 GlyphClass: 3
 Flags: W
@@ -59002,7 +59002,7 @@ Refer: 419 305 N 1 0 0 1 287 0 2
 EndChar
 
 StartChar: longs_j
-Encoding: 65764 -1 2291
+Encoding: 1114340 -1 2291
 Width: 564
 GlyphClass: 3
 Flags: W
@@ -59042,7 +59042,7 @@ Refer: 1718 567 N 1 0 0 1 275 0 2
 EndChar
 
 StartChar: longs_l
-Encoding: 65765 -1 2292
+Encoding: 1114341 -1 2292
 Width: 586
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -59100,7 +59100,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_longs
-Encoding: 65766 -1 2293
+Encoding: 1114342 -1 2293
 Width: 615
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -59167,7 +59167,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_longs_i
-Encoding: 65767 -1 2294
+Encoding: 1114343 -1 2294
 Width: 849
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -59236,7 +59236,7 @@ Refer: 419 305 N 1 0 0 1 551 0 2
 EndChar
 
 StartChar: longs_longs_j
-Encoding: 65768 -1 2295
+Encoding: 1114344 -1 2295
 Width: 844
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -59305,7 +59305,7 @@ Refer: 1718 567 N 1 0 0 1 555 0 2
 EndChar
 
 StartChar: longs_longs_l
-Encoding: 65769 -1 2296
+Encoding: 1114345 -1 2296
 Width: 867
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -59466,7 +59466,7 @@ Refer: 2338 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.slash.cap
-Encoding: 65770 -1 2303
+Encoding: 1114346 -1 2303
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59479,7 +59479,7 @@ Refer: 2304 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.cap
-Encoding: 65771 -1 2304
+Encoding: 1114347 -1 2304
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59502,7 +59502,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.cap
-Encoding: 65772 -1 2305
+Encoding: 1114348 -1 2305
 Width: 529
 VWidth: 1078
 GlyphClass: 2
@@ -59530,7 +59530,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.cap
-Encoding: 65773 -1 2306
+Encoding: 1114349 -1 2306
 Width: 529
 VWidth: 1078
 GlyphClass: 2
@@ -59563,7 +59563,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.cap
-Encoding: 65774 -1 2307
+Encoding: 1114350 -1 2307
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59594,7 +59594,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.cap
-Encoding: 65775 -1 2308
+Encoding: 1114351 -1 2308
 Width: 529
 VWidth: 1078
 GlyphClass: 2
@@ -59631,7 +59631,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.cap
-Encoding: 65776 -1 2309
+Encoding: 1114352 -1 2309
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59662,7 +59662,7 @@ EndSplineSet
 EndChar
 
 StartChar: six.cap
-Encoding: 65777 -1 2310
+Encoding: 1114353 -1 2310
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59690,7 +59690,7 @@ EndSplineSet
 EndChar
 
 StartChar: seven.cap
-Encoding: 65778 -1 2311
+Encoding: 1114354 -1 2311
 Width: 529
 VWidth: 1079
 GlyphClass: 2
@@ -59715,7 +59715,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.cap
-Encoding: 65779 -1 2312
+Encoding: 1114355 -1 2312
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59750,7 +59750,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.cap
-Encoding: 65780 -1 2313
+Encoding: 1114356 -1 2313
 Width: 529
 VWidth: 1077
 GlyphClass: 2
@@ -59778,7 +59778,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.cap.fitted
-Encoding: 65781 -1 2314
+Encoding: 1114357 -1 2314
 Width: 536
 VWidth: 1077
 GlyphClass: 2
@@ -59791,7 +59791,7 @@ Refer: 2315 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.cap.fitted
-Encoding: 65782 -1 2315
+Encoding: 1114358 -1 2315
 Width: 536
 VWidth: 1077
 GlyphClass: 2
@@ -59802,7 +59802,7 @@ Refer: 2304 -1 N 1 0 0 1 3 0 2
 EndChar
 
 StartChar: one.cap.fitted
-Encoding: 65783 -1 2316
+Encoding: 1114359 -1 2316
 Width: 418
 VWidth: 1078
 GlyphClass: 2
@@ -59813,7 +59813,7 @@ Refer: 2305 -1 N 1 0 0 1 -39 0 2
 EndChar
 
 StartChar: two.cap.fitted
-Encoding: 65784 -1 2317
+Encoding: 1114360 -1 2317
 Width: 515
 VWidth: 1078
 GlyphClass: 2
@@ -59824,7 +59824,7 @@ Refer: 2306 -1 N 1 0 0 1 -9 0 2
 EndChar
 
 StartChar: three.cap.fitted
-Encoding: 65785 -1 2318
+Encoding: 1114361 -1 2318
 Width: 508
 VWidth: 1077
 GlyphClass: 2
@@ -59835,7 +59835,7 @@ Refer: 2307 -1 N 1 0 0 1 -8 0 2
 EndChar
 
 StartChar: four.cap.fitted
-Encoding: 65786 -1 2319
+Encoding: 1114362 -1 2319
 Width: 545
 VWidth: 1078
 GlyphClass: 2
@@ -59846,7 +59846,7 @@ Refer: 2308 -1 N 1 0 0 1 -9 0 2
 EndChar
 
 StartChar: five.cap.fitted
-Encoding: 65787 -1 2320
+Encoding: 1114363 -1 2320
 Width: 505
 VWidth: 1077
 GlyphClass: 2
@@ -59857,7 +59857,7 @@ Refer: 2309 -1 N 1 0 0 1 -8 0 2
 EndChar
 
 StartChar: six.cap.fitted
-Encoding: 65788 -1 2321
+Encoding: 1114364 -1 2321
 Width: 516
 VWidth: 1077
 GlyphClass: 2
@@ -59868,7 +59868,7 @@ Refer: 2310 -1 N 1 0 0 1 -5 0 2
 EndChar
 
 StartChar: seven.cap.fitted
-Encoding: 65789 -1 2322
+Encoding: 1114365 -1 2322
 Width: 456
 VWidth: 1079
 GlyphClass: 2
@@ -59879,7 +59879,7 @@ Refer: 2311 -1 N 1 0 0 1 -36 0 2
 EndChar
 
 StartChar: eight.cap.fitted
-Encoding: 65790 -1 2323
+Encoding: 1114366 -1 2323
 Width: 524
 VWidth: 1077
 GlyphClass: 2
@@ -59890,7 +59890,7 @@ Refer: 2312 -1 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: nine.cap.fitted
-Encoding: 65791 -1 2324
+Encoding: 1114367 -1 2324
 Width: 519
 VWidth: 1077
 GlyphClass: 2
@@ -59901,7 +59901,7 @@ Refer: 2313 -1 N 1 0 0 1 -5 0 2
 EndChar
 
 StartChar: zslash.cap.util
-Encoding: 65792 -1 2325
+Encoding: 1114368 -1 2325
 Width: 490
 Flags: W
 LayerCount: 2
@@ -59956,7 +59956,7 @@ Refer: 2181 7580 N -1 0 0 -1 320 995 2
 EndChar
 
 StartChar: J.alt
-Encoding: 65793 -1 2330
+Encoding: 1114369 -1 2330
 Width: 494
 GlyphClass: 2
 Flags: W
@@ -59999,7 +59999,7 @@ EndSplineSet
 EndChar
 
 StartChar: K.alt
-Encoding: 65794 -1 2331
+Encoding: 1114370 -1 2331
 Width: 660
 GlyphClass: 2
 Flags: W
@@ -60056,7 +60056,7 @@ EndSplineSet
 EndChar
 
 StartChar: R.alt
-Encoding: 65795 -1 2332
+Encoding: 1114371 -1 2332
 Width: 609
 GlyphClass: 2
 Flags: W
@@ -60107,7 +60107,7 @@ EndSplineSet
 EndChar
 
 StartChar: W.alt
-Encoding: 65796 -1 2333
+Encoding: 1114372 -1 2333
 Width: 1088
 GlyphClass: 2
 Flags: W
@@ -60179,7 +60179,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0431.ital
-Encoding: 65797 -1 2334
+Encoding: 1114373 -1 2334
 Width: 505
 VWidth: 0
 GlyphClass: 2
@@ -60210,7 +60210,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.scalt
-Encoding: 65798 -1 2335
+Encoding: 1114374 -1 2335
 Width: 591
 VWidth: 0
 GlyphClass: 2
@@ -60256,7 +60256,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.alt
-Encoding: 65799 -1 2336
+Encoding: 1114375 -1 2336
 Width: 555
 GlyphClass: 2
 Flags: W
@@ -60304,7 +60304,7 @@ EndSplineSet
 EndChar
 
 StartChar: t_t
-Encoding: 65800 -1 2337
+Encoding: 1114376 -1 2337
 Width: 661
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -60339,7 +60339,7 @@ LCarets2: 1 0
 EndChar
 
 StartChar: uni0249.dotless
-Encoding: 65801 -1 2338
+Encoding: 1114377 -1 2338
 Width: 303
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
@@ -60359,7 +60359,7 @@ Refer: 1718 567 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni0268.dotless
-Encoding: 65802 -1 2339
+Encoding: 1114378 -1 2339
 Width: 286
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
@@ -60402,7 +60402,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_h
-Encoding: 65803 -1 2340
+Encoding: 1114379 -1 2340
 Width: 852
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -60489,7 +60489,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_k
-Encoding: 65804 -1 2341
+Encoding: 1114380 -1 2341
 Width: 827
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -60587,7 +60587,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_h
-Encoding: 65805 -1 2342
+Encoding: 1114381 -1 2342
 Width: 852
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -60668,7 +60668,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f_h
-Encoding: 65806 -1 2343
+Encoding: 1114382 -1 2343
 Width: 1112
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -60777,7 +60777,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f_k
-Encoding: 65807 -1 2344
+Encoding: 1114383 -1 2344
 Width: 1087
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -60897,7 +60897,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_s
-Encoding: 65808 -1 2345
+Encoding: 1114384 -1 2345
 Width: 661
 GlyphClass: 3
 Flags: W
@@ -60908,7 +60908,7 @@ Refer: 1981 115 N 1 0 0 1 260 0 2
 EndChar
 
 StartChar: uni1EFB
-Encoding: 65809 -1 2346
+Encoding: 1114385 -1 2346
 Width: 0
 VWidth: 0
 Flags: W

--- a/sources/LibertinusSerifDisplay-Regular.sfd
+++ b/sources/LibertinusSerifDisplay-Regular.sfd
@@ -93,7 +93,7 @@ KernClass2: 21 21 "'kern' Kerning 1"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 61 {} 37 {} 0 {} 80 {} 40 {} 0 {} 0 {} 88 {} 0 {} 0 {} 24 {} 24 {} 24 {} -5 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -49 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -24 {} 0 {} -61 {} -44 {} -61 {} -49 {} -49 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -24 {} 0 {} -112 {} -88 {} -49 {} -44 {} -39 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 37 {} 0 {} 0 {} 0 {} -5 {} -34 {} -24 {} 5 {} 10 {} 0 {} -29 {} -29 {} 5 {} 5 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 2 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 2 {} 0 {} 0 {} -12 {} -24 {} 0 {} 10 {} 0 {} 0 {} 0 {} -15 {} -5 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} -5 {} -20 {} -20 {} -20 {} 5 {} 0 {} 0 {} -5 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -24 {} -40 {} -10 {} 7 {} 5 {} 0 {} -5 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} 0 {} -12 {} 0 {} -37 {} 0 {} 0 {} -59 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -308 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 5 {} 0 {} 0 {} 10 {} 12 {} 49 {} 29 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Khaled Hosny" "Philipp H. Poll" "" "" "http://www.linuxlibertine.org" "This Font Software is licensed under the SIL Open Font License, Version 1.1." "https://scripts.sil.org/OFL"
 GaspTable: 3 8 2 17 1 65535 3 0
-Encoding: UnicodeBmp
+Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL For New Fonts
 ExtremaBound: 50
@@ -242,7 +242,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "aboveMark" "'mkmk' Mark to Mark-1" "right" "'mark' Right" "komb_OR" "'mark' Komb OR" "above" "'mark' Above" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle"
-BeginChars: 65732 2274
+BeginChars: 1114307 2274
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -14348,7 +14348,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Adieresis.alt
-Encoding: 65536 -1 346
+Encoding: 1114112 -1 346
 Width: 699
 GlyphClass: 2
 Flags: MW
@@ -15168,7 +15168,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Odieresis.alt
-Encoding: 65537 -1 364
+Encoding: 1114113 -1 364
 Width: 695
 GlyphClass: 2
 Flags: MW
@@ -15403,7 +15403,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Udieresis.alt
-Encoding: 65538 -1 370
+Encoding: 1114114 -1 370
 Width: 668
 GlyphClass: 2
 Flags: MW
@@ -48734,7 +48734,7 @@ EndSplineSet
 EndChar
 
 StartChar: parenleft.sc
-Encoding: 65539 -1 1200
+Encoding: 1114115 -1 1200
 Width: 298
 GlyphClass: 2
 Flags: MW
@@ -48753,7 +48753,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: parenright.sc
-Encoding: 65540 -1 1201
+Encoding: 1114116 -1 1201
 Width: 298
 GlyphClass: 2
 Flags: MW
@@ -48772,7 +48772,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketleft.sc
-Encoding: 65541 -1 1202
+Encoding: 1114117 -1 1202
 Width: 356
 GlyphClass: 2
 Flags: MW
@@ -48793,7 +48793,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: bracketright.sc
-Encoding: 65542 -1 1203
+Encoding: 1114118 -1 1203
 Width: 356
 GlyphClass: 2
 Flags: MW
@@ -48814,7 +48814,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceleft.sc
-Encoding: 65543 -1 1204
+Encoding: 1114119 -1 1204
 Width: 267
 GlyphClass: 2
 Flags: MW
@@ -48842,7 +48842,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: braceright.sc
-Encoding: 65544 -1 1205
+Encoding: 1114120 -1 1205
 Width: 267
 GlyphClass: 2
 Flags: MW
@@ -48870,7 +48870,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: exclamdown.sc
-Encoding: 65545 -1 1206
+Encoding: 1114121 -1 1206
 Width: 288
 GlyphClass: 2
 Flags: MW
@@ -48896,7 +48896,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: questiondown.sc
-Encoding: 65546 -1 1207
+Encoding: 1114122 -1 1207
 Width: 420
 GlyphClass: 2
 Flags: MW
@@ -48932,7 +48932,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotleft.sc
-Encoding: 65547 -1 1208
+Encoding: 1114123 -1 1208
 Width: 543
 GlyphClass: 2
 Flags: MW
@@ -48960,7 +48960,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guillemotright.sc
-Encoding: 65548 -1 1209
+Encoding: 1114124 -1 1209
 Width: 543
 GlyphClass: 2
 Flags: MW
@@ -48988,7 +48988,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglleft.sc
-Encoding: 65549 -1 1210
+Encoding: 1114125 -1 1210
 Width: 300
 GlyphClass: 2
 Flags: MW
@@ -49010,7 +49010,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: guilsinglright.sc
-Encoding: 65550 -1 1211
+Encoding: 1114126 -1 1211
 Width: 300
 GlyphClass: 2
 Flags: MW
@@ -49032,7 +49032,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_f
-Encoding: 65551 -1 1212
+Encoding: 1114127 -1 1212
 Width: 587
 GlyphClass: 3
 Flags: MW
@@ -49095,7 +49095,7 @@ LCarets2: 1 261
 EndChar
 
 StartChar: f_i
-Encoding: 65552 -1 1213
+Encoding: 1114128 -1 1213
 Width: 539
 GlyphClass: 3
 Flags: MW
@@ -49147,7 +49147,7 @@ LCarets2: 1 277
 EndChar
 
 StartChar: f_l
-Encoding: 65553 -1 1214
+Encoding: 1114129 -1 1214
 Width: 538
 GlyphClass: 3
 Flags: MW
@@ -49203,7 +49203,7 @@ LCarets2: 1 288
 EndChar
 
 StartChar: f_f_i
-Encoding: 65554 -1 1215
+Encoding: 1114130 -1 1215
 Width: 807
 GlyphClass: 3
 Flags: MW
@@ -49276,7 +49276,7 @@ LCarets2: 2 266 550
 EndChar
 
 StartChar: longs_t
-Encoding: 65555 -1 1216
+Encoding: 1114131 -1 1216
 Width: 554
 GlyphClass: 3
 Flags: MW
@@ -49329,7 +49329,7 @@ LCarets2: 1 265
 EndChar
 
 StartChar: .notdef
-Encoding: 65556 -1 1217
+Encoding: 1114132 -1 1217
 Width: 500
 Flags: MW
 LayerCount: 2
@@ -51350,7 +51350,7 @@ EndSplineSet
 EndChar
 
 StartChar: Yen.fitted
-Encoding: 65557 -1 1262
+Encoding: 1114133 -1 1262
 Width: 536
 GlyphClass: 2
 Flags: MW
@@ -51427,7 +51427,7 @@ EndSplineSet
 EndChar
 
 StartChar: a.alt
-Encoding: 65558 -1 1263
+Encoding: 1114134 -1 1263
 Width: 451
 Flags: MW
 AnchorPoint: "above" 209 645 basechar 0
@@ -51582,7 +51582,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE01F
-Encoding: 65559 -1 1267
+Encoding: 1114135 -1 1267
 Width: 271
 Flags: MW
 LayerCount: 2
@@ -51602,7 +51602,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.oldstyle
-Encoding: 65560 -1 1268
+Encoding: 1114136 -1 1268
 Width: 514
 GlyphClass: 2
 Flags: MW
@@ -51623,7 +51623,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.oldstyle
-Encoding: 65561 -1 1269
+Encoding: 1114137 -1 1269
 Width: 322
 GlyphClass: 2
 Flags: MW
@@ -51850,7 +51850,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE001
-Encoding: 65562 -1 1271
+Encoding: 1114138 -1 1271
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -51904,7 +51904,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE002
-Encoding: 65563 -1 1272
+Encoding: 1114139 -1 1272
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -51955,7 +51955,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE003
-Encoding: 65564 -1 1273
+Encoding: 1114140 -1 1273
 Width: 1157
 Flags: MW
 LayerCount: 2
@@ -52211,7 +52211,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE004
-Encoding: 65565 -1 1275
+Encoding: 1114141 -1 1275
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -52420,7 +52420,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE005
-Encoding: 65566 -1 1279
+Encoding: 1114142 -1 1279
 Width: 802
 Flags: MW
 LayerCount: 2
@@ -52445,7 +52445,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE006
-Encoding: 65567 -1 1280
+Encoding: 1114143 -1 1280
 Width: 1065
 Flags: MW
 LayerCount: 2
@@ -52464,7 +52464,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE007
-Encoding: 65568 -1 1281
+Encoding: 1114144 -1 1281
 Width: 2082
 Flags: MW
 LayerCount: 2
@@ -52483,7 +52483,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE008
-Encoding: 65569 -1 1282
+Encoding: 1114145 -1 1282
 Width: 6272
 Flags: MW
 LayerCount: 2
@@ -52548,7 +52548,7 @@ EndSplineSet
 EndChar
 
 StartChar: s_t
-Encoding: 65570 -1 1283
+Encoding: 1114146 -1 1283
 Width: 657
 GlyphClass: 3
 Flags: MW
@@ -54500,7 +54500,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.fitted
-Encoding: 65571 -1 1349
+Encoding: 1114147 -1 1349
 Width: 377
 GlyphClass: 2
 Flags: MW
@@ -54529,7 +54529,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.fitted
-Encoding: 65572 -1 1350
+Encoding: 1114148 -1 1350
 Width: 462
 GlyphClass: 2
 Flags: MW
@@ -54563,7 +54563,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.fitted
-Encoding: 65573 -1 1351
+Encoding: 1114149 -1 1351
 Width: 472
 GlyphClass: 2
 Flags: MW
@@ -54595,7 +54595,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.fitted
-Encoding: 65574 -1 1352
+Encoding: 1114150 -1 1352
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -54632,7 +54632,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.fitted
-Encoding: 65575 -1 1353
+Encoding: 1114151 -1 1353
 Width: 442
 GlyphClass: 2
 Flags: MW
@@ -54663,7 +54663,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.fitted
-Encoding: 65576 -1 1354
+Encoding: 1114152 -1 1354
 Width: 474
 GlyphClass: 2
 Flags: MW
@@ -54690,7 +54690,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.fitted
-Encoding: 65577 -1 1355
+Encoding: 1114153 -1 1355
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -54725,7 +54725,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.oldstyle
-Encoding: 65578 -1 1356
+Encoding: 1114154 -1 1356
 Width: 440
 GlyphClass: 2
 Flags: MW
@@ -54755,7 +54755,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.oldstyle
-Encoding: 65579 -1 1357
+Encoding: 1114155 -1 1357
 Width: 448
 GlyphClass: 2
 Flags: MW
@@ -54787,7 +54787,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE00E
-Encoding: 65580 -1 1358
+Encoding: 1114156 -1 1358
 Width: 695
 Flags: MW
 LayerCount: 2
@@ -68141,7 +68141,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f_j
-Encoding: 65581 -1 1668
+Encoding: 1114157 -1 1668
 Width: 529
 GlyphClass: 3
 Flags: MW
@@ -68266,7 +68266,7 @@ Colour: ffffff
 EndChar
 
 StartChar: zero.slash.fitted
-Encoding: 65582 -1 1672
+Encoding: 1114158 -1 1672
 Width: 483
 GlyphClass: 2
 Flags: MW
@@ -68304,7 +68304,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Q_u
-Encoding: 65583 -1 1673
+Encoding: 1114159 -1 1673
 Width: 1251
 Flags: MW
 LayerCount: 2
@@ -68372,7 +68372,7 @@ Colour: ff9ccc
 EndChar
 
 StartChar: T_h
-Encoding: 65584 -1 1674
+Encoding: 1114160 -1 1674
 Width: 1037
 GlyphClass: 3
 Flags: MW
@@ -68435,7 +68435,7 @@ LCarets2: 1 472
 EndChar
 
 StartChar: zero.fitted
-Encoding: 65585 -1 1675
+Encoding: 1114161 -1 1675
 Width: 483
 GlyphClass: 2
 Flags: MW
@@ -68472,7 +68472,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.fitted
-Encoding: 65586 -1 1677
+Encoding: 1114162 -1 1677
 Width: 428
 GlyphClass: 2
 Flags: MW
@@ -68498,7 +68498,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.fitted
-Encoding: 65587 -1 1678
+Encoding: 1114163 -1 1678
 Width: 468
 GlyphClass: 2
 Flags: MW
@@ -68525,7 +68525,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: Euro.fitted
-Encoding: 65588 -1 1679
+Encoding: 1114164 -1 1679
 Width: 642
 GlyphClass: 2
 Flags: MW
@@ -79920,7 +79920,7 @@ EndSplineSet
 EndChar
 
 StartChar: q.superior
-Encoding: 65589 -1 1958
+Encoding: 1114165 -1 1958
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -80011,7 +80011,7 @@ Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 EndChar
 
 StartChar: zero.slash
-Encoding: 65590 -1 1960
+Encoding: 1114166 -1 1960
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80048,7 +80048,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE100
-Encoding: 65591 -1 1961
+Encoding: 1114167 -1 1961
 Width: 695
 Flags: MW
 LayerCount: 2
@@ -80068,7 +80068,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.oldstyle
-Encoding: 65592 -1 1962
+Encoding: 1114168 -1 1962
 Width: 460
 GlyphClass: 2
 Flags: MW
@@ -80104,7 +80104,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.oldstyle
-Encoding: 65593 -1 1963
+Encoding: 1114169 -1 1963
 Width: 435
 GlyphClass: 2
 Flags: MW
@@ -80135,7 +80135,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.oldstyle
-Encoding: 65594 -1 1964
+Encoding: 1114170 -1 1964
 Width: 464
 GlyphClass: 2
 Flags: MW
@@ -80162,7 +80162,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.oldstyle
-Encoding: 65595 -1 1965
+Encoding: 1114171 -1 1965
 Width: 452
 GlyphClass: 2
 Flags: MW
@@ -80188,7 +80188,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.oldstyle
-Encoding: 65596 -1 1966
+Encoding: 1114172 -1 1966
 Width: 465
 Flags: MW
 LayerCount: 2
@@ -80222,7 +80222,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.oldstyle
-Encoding: 65597 -1 1967
+Encoding: 1114173 -1 1967
 Width: 464
 GlyphClass: 2
 Flags: MW
@@ -80249,7 +80249,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0F9
-Encoding: 65598 -1 1968
+Encoding: 1114174 -1 1968
 Width: 623
 Flags: MW
 LayerCount: 2
@@ -80284,7 +80284,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: uniE0FB
-Encoding: 65599 -1 1969
+Encoding: 1114175 -1 1969
 Width: 640
 Flags: MW
 LayerCount: 2
@@ -80296,7 +80296,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t_t
-Encoding: 65600 -1 1970
+Encoding: 1114176 -1 1970
 Width: 603
 GlyphClass: 3
 Flags: MW
@@ -80347,7 +80347,7 @@ LCarets2: 1 306
 EndChar
 
 StartChar: c_t
-Encoding: 65601 -1 1971
+Encoding: 1114177 -1 1971
 Width: 703
 GlyphClass: 3
 Flags: MW
@@ -80446,7 +80446,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.taboldstyle
-Encoding: 65602 -1 1974
+Encoding: 1114178 -1 1974
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80467,7 +80467,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.taboldstyle
-Encoding: 65603 -1 1975
+Encoding: 1114179 -1 1975
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80494,7 +80494,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: two.taboldstyle
-Encoding: 65604 -1 1976
+Encoding: 1114180 -1 1976
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80525,7 +80525,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: three.taboldstyle
-Encoding: 65605 -1 1977
+Encoding: 1114181 -1 1977
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80557,7 +80557,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: four.taboldstyle
-Encoding: 65606 -1 1978
+Encoding: 1114182 -1 1978
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80594,7 +80594,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: five.taboldstyle
-Encoding: 65607 -1 1979
+Encoding: 1114183 -1 1979
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80625,7 +80625,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: six.taboldstyle
-Encoding: 65608 -1 1980
+Encoding: 1114184 -1 1980
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80652,7 +80652,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: seven.taboldstyle
-Encoding: 65609 -1 1981
+Encoding: 1114185 -1 1981
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80678,7 +80678,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: eight.taboldstyle
-Encoding: 65610 -1 1982
+Encoding: 1114186 -1 1982
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80714,7 +80714,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: nine.taboldstyle
-Encoding: 65611 -1 1983
+Encoding: 1114187 -1 1983
 Width: 465
 GlyphClass: 2
 Flags: MW
@@ -80783,7 +80783,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE104
-Encoding: 65612 -1 1985
+Encoding: 1114188 -1 1985
 Width: 611
 Flags: MW
 LayerCount: 2
@@ -80880,7 +80880,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE105
-Encoding: 65613 -1 1986
+Encoding: 1114189 -1 1986
 Width: 835
 Flags: MW
 LayerCount: 2
@@ -81021,7 +81021,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE106
-Encoding: 65614 -1 1987
+Encoding: 1114190 -1 1987
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -81113,7 +81113,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE107
-Encoding: 65615 -1 1988
+Encoding: 1114191 -1 1988
 Width: 730
 Flags: MW
 LayerCount: 2
@@ -81194,7 +81194,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE00B
-Encoding: 65616 -1 1989
+Encoding: 1114192 -1 1989
 Width: 407
 Flags: MW
 LayerCount: 2
@@ -81493,7 +81493,7 @@ EndSplineSet
 EndChar
 
 StartChar: hyphen.cap
-Encoding: 65617 -1 1996
+Encoding: 1114193 -1 1996
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -81536,7 +81536,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE101
-Encoding: 65618 -1 1998
+Encoding: 1114194 -1 1998
 Width: 759
 Flags: MW
 LayerCount: 2
@@ -81556,7 +81556,7 @@ EndSplineSet
 EndChar
 
 StartChar: b.inferior
-Encoding: 65619 -1 1999
+Encoding: 1114195 -1 1999
 Width: 297
 GlyphClass: 2
 Flags: MW
@@ -81591,7 +81591,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: c.inferior
-Encoding: 65620 -1 2000
+Encoding: 1114196 -1 2000
 Width: 282
 GlyphClass: 2
 Flags: MW
@@ -81616,7 +81616,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: d.inferior
-Encoding: 65621 -1 2001
+Encoding: 1114197 -1 2001
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -81655,7 +81655,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: f.inferior
-Encoding: 65622 -1 2002
+Encoding: 1114198 -1 2002
 Width: 253
 GlyphClass: 2
 Flags: MW
@@ -81700,7 +81700,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: g.inferior
-Encoding: 65623 -1 2003
+Encoding: 1114199 -1 2003
 Width: 315
 GlyphClass: 2
 Flags: MW
@@ -81750,7 +81750,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: h.inferior
-Encoding: 65624 -1 2004
+Encoding: 1114200 -1 2004
 Width: 307
 GlyphClass: 2
 Flags: MW
@@ -81799,7 +81799,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: i.inferior
-Encoding: 65625 -1 2005
+Encoding: 1114201 -1 2005
 Width: 194
 GlyphClass: 2
 Flags: MW
@@ -81830,7 +81830,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: j.inferior
-Encoding: 65626 -1 2006
+Encoding: 1114202 -1 2006
 Width: 207
 GlyphClass: 2
 Flags: MW
@@ -81864,7 +81864,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: k.inferior
-Encoding: 65627 -1 2007
+Encoding: 1114203 -1 2007
 Width: 318
 GlyphClass: 2
 Flags: MW
@@ -81924,7 +81924,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: l.inferior
-Encoding: 65628 -1 2008
+Encoding: 1114204 -1 2008
 Width: 161
 GlyphClass: 2
 Flags: MW
@@ -81950,7 +81950,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: m.inferior
-Encoding: 65629 -1 2009
+Encoding: 1114205 -1 2009
 Width: 485
 GlyphClass: 2
 Flags: MW
@@ -82016,7 +82016,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: n.inferior
-Encoding: 65630 -1 2010
+Encoding: 1114206 -1 2010
 Width: 342
 GlyphClass: 2
 Flags: MW
@@ -82054,7 +82054,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: p.inferior
-Encoding: 65631 -1 2011
+Encoding: 1114207 -1 2011
 Width: 305
 GlyphClass: 2
 Flags: MW
@@ -82097,7 +82097,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: q.inferior
-Encoding: 65632 -1 2012
+Encoding: 1114208 -1 2012
 Width: 308
 GlyphClass: 2
 Flags: MW
@@ -82135,7 +82135,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: r.inferior
-Encoding: 65633 -1 2013
+Encoding: 1114209 -1 2013
 Width: 246
 GlyphClass: 2
 Flags: MW
@@ -82175,7 +82175,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: s.inferior
-Encoding: 65634 -1 2014
+Encoding: 1114210 -1 2014
 Width: 253
 GlyphClass: 2
 Flags: MW
@@ -82206,7 +82206,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: t.inferior
-Encoding: 65635 -1 2015
+Encoding: 1114211 -1 2015
 Width: 206
 GlyphClass: 2
 Flags: MW
@@ -82239,7 +82239,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: u.inferior
-Encoding: 65636 -1 2016
+Encoding: 1114212 -1 2016
 Width: 319
 GlyphClass: 2
 Flags: MW
@@ -82283,7 +82283,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: v.inferior
-Encoding: 65637 -1 2017
+Encoding: 1114213 -1 2017
 Width: 314
 GlyphClass: 2
 Flags: MW
@@ -82325,7 +82325,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: w.inferior
-Encoding: 65638 -1 2018
+Encoding: 1114214 -1 2018
 Width: 445
 GlyphClass: 2
 Flags: MW
@@ -82386,7 +82386,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: y.inferior
-Encoding: 65639 -1 2019
+Encoding: 1114215 -1 2019
 Width: 338
 GlyphClass: 2
 Flags: MW
@@ -82434,7 +82434,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: z.inferior
-Encoding: 65640 -1 2020
+Encoding: 1114216 -1 2020
 Width: 274
 GlyphClass: 2
 Flags: MW
@@ -83877,7 +83877,7 @@ Colour: ff00ff
 EndChar
 
 StartChar: longs_i
-Encoding: 65641 -1 2045
+Encoding: 1114217 -1 2045
 Width: 532
 GlyphClass: 3
 Flags: MW
@@ -84051,7 +84051,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE128
-Encoding: 65642 -1 2051
+Encoding: 1114218 -1 2051
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -84071,7 +84071,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE129
-Encoding: 65643 -1 2052
+Encoding: 1114219 -1 2052
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -84095,7 +84095,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE12A
-Encoding: 65644 -1 2053
+Encoding: 1114220 -1 2053
 Width: 180
 Flags: MW
 LayerCount: 2
@@ -84494,7 +84494,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE130
-Encoding: 65645 -1 2063
+Encoding: 1114221 -1 2063
 Width: 166
 Flags: MW
 LayerCount: 2
@@ -85263,7 +85263,7 @@ EndSplineSet
 EndChar
 
 StartChar: grave.cap
-Encoding: 65646 -1 2088
+Encoding: 1114222 -1 2088
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85282,7 +85282,7 @@ EndSplineSet
 EndChar
 
 StartChar: acute.cap
-Encoding: 65647 -1 2089
+Encoding: 1114223 -1 2089
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85301,7 +85301,7 @@ EndSplineSet
 EndChar
 
 StartChar: circumflex.cap
-Encoding: 65648 -1 2090
+Encoding: 1114224 -1 2090
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85322,7 +85322,7 @@ EndSplineSet
 EndChar
 
 StartChar: caron.cap
-Encoding: 65649 -1 2091
+Encoding: 1114225 -1 2091
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85342,7 +85342,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cap
-Encoding: 65650 -1 2092
+Encoding: 1114226 -1 2092
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85361,7 +85361,7 @@ EndSplineSet
 EndChar
 
 StartChar: hungarumlaut.cap
-Encoding: 65651 -1 2093
+Encoding: 1114227 -1 2093
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85391,7 +85391,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni030F.cap
-Encoding: 65652 -1 2094
+Encoding: 1114228 -1 2094
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85421,7 +85421,7 @@ EndSplineSet
 EndChar
 
 StartChar: breveinvertedcmb.cap
-Encoding: 65653 -1 2095
+Encoding: 1114229 -1 2095
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85440,7 +85440,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyrcap
-Encoding: 65654 -1 2096
+Encoding: 1114230 -1 2096
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85463,7 +85463,7 @@ EndSplineSet
 EndChar
 
 StartChar: breve.cyr
-Encoding: 65655 -1 2097
+Encoding: 1114231 -1 2097
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85487,7 +85487,7 @@ EndSplineSet
 EndChar
 
 StartChar: dieresis.cap
-Encoding: 65656 -1 2098
+Encoding: 1114232 -1 2098
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85509,7 +85509,7 @@ EndSplineSet
 EndChar
 
 StartChar: hookabovecomb.cap
-Encoding: 65657 -1 2099
+Encoding: 1114233 -1 2099
 Width: 0
 GlyphClass: 4
 Flags: MW
@@ -85534,7 +85534,7 @@ EndSplineSet
 EndChar
 
 StartChar: dotaccent.cap
-Encoding: 65658 -1 2100
+Encoding: 1114234 -1 2100
 Width: 291
 GlyphClass: 4
 Flags: MW
@@ -87421,7 +87421,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE01C
-Encoding: 65659 -1 2173
+Encoding: 1114235 -1 2173
 Width: 516
 Flags: MW
 LayerCount: 2
@@ -87461,7 +87461,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE01E
-Encoding: 65660 -1 2174
+Encoding: 1114236 -1 2174
 Width: 585
 Flags: MW
 LayerCount: 2
@@ -87501,7 +87501,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.cap
-Encoding: 65661 -1 2175
+Encoding: 1114237 -1 2175
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -87526,7 +87526,7 @@ EndSplineSet
 EndChar
 
 StartChar: one.cap
-Encoding: 65662 -1 2176
+Encoding: 1114238 -1 2176
 Width: 502
 VWidth: 1078
 GlyphClass: 2
@@ -87555,7 +87555,7 @@ EndSplineSet
 EndChar
 
 StartChar: two.cap
-Encoding: 65663 -1 2177
+Encoding: 1114239 -1 2177
 Width: 502
 VWidth: 1078
 GlyphClass: 2
@@ -87589,7 +87589,7 @@ EndSplineSet
 EndChar
 
 StartChar: three.cap
-Encoding: 65664 -1 2178
+Encoding: 1114240 -1 2178
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -87621,7 +87621,7 @@ EndSplineSet
 EndChar
 
 StartChar: four.cap
-Encoding: 65665 -1 2179
+Encoding: 1114241 -1 2179
 Width: 502
 VWidth: 1078
 GlyphClass: 2
@@ -87658,7 +87658,7 @@ EndSplineSet
 EndChar
 
 StartChar: five.cap
-Encoding: 65666 -1 2180
+Encoding: 1114242 -1 2180
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -87689,7 +87689,7 @@ EndSplineSet
 EndChar
 
 StartChar: six.cap
-Encoding: 65667 -1 2181
+Encoding: 1114243 -1 2181
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -87716,7 +87716,7 @@ EndSplineSet
 EndChar
 
 StartChar: seven.cap
-Encoding: 65668 -1 2182
+Encoding: 1114244 -1 2182
 Width: 502
 VWidth: 1076
 GlyphClass: 2
@@ -87742,7 +87742,7 @@ EndSplineSet
 EndChar
 
 StartChar: eight.cap
-Encoding: 65669 -1 2183
+Encoding: 1114245 -1 2183
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -87778,7 +87778,7 @@ EndSplineSet
 EndChar
 
 StartChar: nine.cap
-Encoding: 65670 -1 2184
+Encoding: 1114246 -1 2184
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -87830,7 +87830,7 @@ EndSplineSet
 EndChar
 
 StartChar: u1F12F
-Encoding: 65671 127279 2186
+Encoding: 127279 127279 2186
 Width: 695
 GlyphClass: 2
 Flags: MW
@@ -87863,7 +87863,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE00D
-Encoding: 65672 -1 2187
+Encoding: 1114247 -1 2187
 Width: 695
 Flags: MW
 LayerCount: 2
@@ -88035,7 +88035,7 @@ EndSplineSet
 EndChar
 
 StartChar: W.alt
-Encoding: 65673 -1 2192
+Encoding: 1114248 -1 2192
 Width: 1017
 GlyphClass: 2
 Flags: MW
@@ -88872,7 +88872,7 @@ EndSplineSet
 EndChar
 
 StartChar: uniE138
-Encoding: 65674 -1 2213
+Encoding: 1114249 -1 2213
 Width: 1014
 Flags: MW
 LayerCount: 2
@@ -89023,7 +89023,7 @@ EndSplineSet
 EndChar
 
 StartChar: Eng.UCStyle
-Encoding: 65675 -1 2216
+Encoding: 1114250 -1 2216
 Width: 716
 VWidth: 0
 GlyphClass: 2
@@ -89075,7 +89075,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0444.alt
-Encoding: 65676 -1 2217
+Encoding: 1114251 -1 2217
 Width: 628
 VWidth: 0
 Flags: W
@@ -89123,7 +89123,7 @@ EndSplineSet
 EndChar
 
 StartChar: zero.slash.cap
-Encoding: 65677 -1 2218
+Encoding: 1114252 -1 2218
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -89136,7 +89136,7 @@ Refer: 2175 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.slash.cap.fitted
-Encoding: 65678 -1 2219
+Encoding: 1114253 -1 2219
 Width: 519
 VWidth: 1077
 GlyphClass: 2
@@ -89149,7 +89149,7 @@ Refer: 2220 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: zero.cap.fitted
-Encoding: 65679 -1 2220
+Encoding: 1114254 -1 2220
 Width: 519
 VWidth: 1077
 GlyphClass: 2
@@ -89160,7 +89160,7 @@ Refer: 2175 -1 N 1 0 0 1 10 0 2
 EndChar
 
 StartChar: one.cap.fitted
-Encoding: 65680 -1 2221
+Encoding: 1114255 -1 2221
 Width: 404
 VWidth: 1078
 GlyphClass: 2
@@ -89171,7 +89171,7 @@ Refer: 2176 -1 N 1 0 0 1 -48 0 2
 EndChar
 
 StartChar: two.cap.fitted
-Encoding: 65681 -1 2222
+Encoding: 1114256 -1 2222
 Width: 495
 VWidth: 1078
 GlyphClass: 2
@@ -89182,7 +89182,7 @@ Refer: 2177 -1 N 1 0 0 1 -13 0 2
 EndChar
 
 StartChar: three.cap.fitted
-Encoding: 65682 -1 2223
+Encoding: 1114257 -1 2223
 Width: 505
 VWidth: 1077
 GlyphClass: 2
@@ -89193,7 +89193,7 @@ Refer: 2178 -1 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: four.cap.fitted
-Encoding: 65683 -1 2224
+Encoding: 1114258 -1 2224
 Width: 510
 VWidth: 1078
 GlyphClass: 2
@@ -89204,7 +89204,7 @@ Refer: 2179 -1 N 1 0 0 1 6 0 2
 EndChar
 
 StartChar: five.cap.fitted
-Encoding: 65684 -1 2225
+Encoding: 1114259 -1 2225
 Width: 473
 VWidth: 1077
 GlyphClass: 2
@@ -89215,7 +89215,7 @@ Refer: 2180 -1 N 1 0 0 1 -16 0 2
 EndChar
 
 StartChar: six.cap.fitted
-Encoding: 65685 -1 2226
+Encoding: 1114260 -1 2226
 Width: 508
 VWidth: 1077
 GlyphClass: 2
@@ -89226,7 +89226,7 @@ Refer: 2181 -1 N 1 0 0 1 -2 0 2
 EndChar
 
 StartChar: seven.cap.fitted
-Encoding: 65686 -1 2227
+Encoding: 1114261 -1 2227
 Width: 458
 VWidth: 1076
 GlyphClass: 2
@@ -89237,7 +89237,7 @@ Refer: 2182 -1 N 1 0 0 1 -16 0 2
 EndChar
 
 StartChar: eight.cap.fitted
-Encoding: 65687 -1 2228
+Encoding: 1114262 -1 2228
 Width: 497
 VWidth: 1077
 GlyphClass: 2
@@ -89248,7 +89248,7 @@ Refer: 2183 -1 N 1 0 0 1 -4 0 2
 EndChar
 
 StartChar: nine.cap.fitted
-Encoding: 65688 -1 2229
+Encoding: 1114263 -1 2229
 Width: 502
 VWidth: 1077
 GlyphClass: 2
@@ -89259,7 +89259,7 @@ Refer: 2184 -1 N 1 0 0 1 -3 0 2
 EndChar
 
 StartChar: zslash.cap.util
-Encoding: 65689 -1 2230
+Encoding: 1114264 -1 2230
 Width: 465
 Flags: W
 LayerCount: 2
@@ -89274,7 +89274,7 @@ EndSplineSet
 EndChar
 
 StartChar: c_h
-Encoding: 65690 -1 2231
+Encoding: 1114265 -1 2231
 Width: 888
 GlyphClass: 3
 LigCaretCntFixed: 1
@@ -89287,7 +89287,7 @@ LCarets2: 1 394
 EndChar
 
 StartChar: c_k
-Encoding: 65691 -1 2232
+Encoding: 1114266 -1 2232
 Width: 876
 GlyphClass: 3
 LigCaretCntFixed: 1
@@ -89300,7 +89300,7 @@ LCarets2: 1 393
 EndChar
 
 StartChar: t_z
-Encoding: 65692 -1 2233
+Encoding: 1114267 -1 2233
 Width: 523
 GlyphClass: 3
 Flags: W
@@ -89349,7 +89349,7 @@ EndSplineSet
 EndChar
 
 StartChar: J.alt
-Encoding: 65693 -1 2234
+Encoding: 1114268 -1 2234
 Width: 414
 GlyphClass: 2
 Flags: W
@@ -89392,7 +89392,7 @@ EndSplineSet
 EndChar
 
 StartChar: K.alt
-Encoding: 65694 -1 2235
+Encoding: 1114269 -1 2235
 Width: 646
 GlyphClass: 2
 Flags: W
@@ -89441,7 +89441,7 @@ EndSplineSet
 EndChar
 
 StartChar: R.alt
-Encoding: 65695 -1 2236
+Encoding: 1114270 -1 2236
 Width: 625
 GlyphClass: 2
 Flags: W
@@ -89488,7 +89488,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni1E9E.alt
-Encoding: 65696 -1 2237
+Encoding: 1114271 -1 2237
 Width: 970
 GlyphClass: 2
 Flags: W
@@ -89499,7 +89499,7 @@ Refer: 267 83 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: germandbls.alt
-Encoding: 65697 -1 2238
+Encoding: 1114272 -1 2238
 Width: 541
 GlyphClass: 2
 Flags: W
@@ -89541,7 +89541,7 @@ EndSplineSet
 EndChar
 
 StartChar: germandbls.ss03
-Encoding: 65698 -1 2239
+Encoding: 1114273 -1 2239
 Width: 749
 GlyphClass: 2
 Flags: W
@@ -89552,7 +89552,7 @@ Refer: 1790 115 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: ampersand.alt
-Encoding: 65699 -1 2240
+Encoding: 1114274 -1 2240
 Width: 722
 GlyphClass: 2
 Flags: W
@@ -89600,7 +89600,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0431.ital
-Encoding: 65700 -1 2241
+Encoding: 1114275 -1 2241
 Width: 505
 GlyphClass: 2
 Flags: W
@@ -89631,7 +89631,7 @@ EndSplineSet
 EndChar
 
 StartChar: h.alt
-Encoding: 65701 -1 2242
+Encoding: 1114276 -1 2242
 Width: 521
 GlyphClass: 2
 Flags: W
@@ -89670,7 +89670,7 @@ EndSplineSet
 EndChar
 
 StartChar: y.alt
-Encoding: 65702 -1 2243
+Encoding: 1114277 -1 2243
 Width: 514
 GlyphClass: 2
 Flags: W
@@ -89720,7 +89720,7 @@ EndSplineSet
 EndChar
 
 StartChar: f.short
-Encoding: 65703 -1 2244
+Encoding: 1114278 -1 2244
 Width: 321
 GlyphClass: 2
 Flags: W
@@ -89764,7 +89764,7 @@ EndSplineSet
 EndChar
 
 StartChar: fmini.util
-Encoding: 65704 -1 2245
+Encoding: 1114279 -1 2245
 Width: 410
 Flags: W
 LayerCount: 2
@@ -89805,7 +89805,7 @@ EndSplineSet
 EndChar
 
 StartChar: f_f_l
-Encoding: 65705 -1 2246
+Encoding: 1114280 -1 2246
 Width: 807
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -89819,7 +89819,7 @@ LCarets2: 2 276 550
 EndChar
 
 StartChar: f_f.short
-Encoding: 65706 -1 2247
+Encoding: 1114281 -1 2247
 Width: 587
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -89833,7 +89833,7 @@ LCarets2: 1 0
 EndChar
 
 StartChar: f_f_j
-Encoding: 65707 -1 2248
+Encoding: 1114282 -1 2248
 Width: 791
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -89847,7 +89847,7 @@ LCarets2: 2 274 590
 EndChar
 
 StartChar: f_t
-Encoding: 65708 -1 2249
+Encoding: 1114283 -1 2249
 Width: 579
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -89868,7 +89868,7 @@ LCarets2: 1 0
 EndChar
 
 StartChar: longs_j
-Encoding: 65709 -1 2250
+Encoding: 1114284 -1 2250
 Width: 532
 GlyphClass: 3
 LigCaretCntFixed: 1
@@ -89923,7 +89923,7 @@ LCarets2: 1 283
 EndChar
 
 StartChar: longsmaxi.util
-Encoding: 65710 -1 2251
+Encoding: 1114285 -1 2251
 Width: 330
 Flags: W
 LayerCount: 2
@@ -89956,7 +89956,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_l
-Encoding: 65711 -1 2252
+Encoding: 1114286 -1 2252
 Width: 529
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -89970,7 +89970,7 @@ LCarets2: 1 288
 EndChar
 
 StartChar: longsmini.util
-Encoding: 65712 -1 2253
+Encoding: 1114287 -1 2253
 Width: 410
 Flags: W
 LayerCount: 2
@@ -90005,7 +90005,7 @@ EndSplineSet
 EndChar
 
 StartChar: longs_longs
-Encoding: 65713 -1 2254
+Encoding: 1114288 -1 2254
 Width: 561
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90022,7 +90022,7 @@ LCarets2: 1 284
 EndChar
 
 StartChar: longs_longs_i
-Encoding: 65714 -1 2255
+Encoding: 1114289 -1 2255
 Width: 802
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90036,7 +90036,7 @@ LCarets2: 2 285 549
 EndChar
 
 StartChar: longs_longs_j
-Encoding: 65715 -1 2256
+Encoding: 1114290 -1 2256
 Width: 803
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90050,7 +90050,7 @@ LCarets2: 2 282 551
 EndChar
 
 StartChar: longs_longs_l
-Encoding: 65716 -1 2257
+Encoding: 1114291 -1 2257
 Width: 796
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90064,7 +90064,7 @@ LCarets2: 2 286 554
 EndChar
 
 StartChar: Q.u
-Encoding: 65717 -1 2258
+Encoding: 1114292 -1 2258
 Width: 695
 GlyphClass: 2
 Flags: W
@@ -90103,7 +90103,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0268.dotless
-Encoding: 65718 -1 2259
+Encoding: 1114293 -1 2259
 Width: 267
 GlyphClass: 2
 Flags: W
@@ -90144,7 +90144,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0249.dotless
-Encoding: 65719 -1 2260
+Encoding: 1114294 -1 2260
 Width: 272
 Flags: W
 AnchorPoint: "above" 140 645 basechar 0
@@ -90184,7 +90184,7 @@ EndSplineSet
 EndChar
 
 StartChar: uni0249
-Encoding: 65720 -1 2261
+Encoding: 1114295 -1 2261
 Width: 272
 Flags: W
 AnchorPoint: "middle" 154 220 basechar 0
@@ -90206,7 +90206,7 @@ Colour: ffff
 EndChar
 
 StartChar: f_f_h
-Encoding: 65721 -1 2263
+Encoding: 1114296 -1 2263
 Width: 1062
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90218,7 +90218,7 @@ Refer: 2245 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: f_f_k
-Encoding: 65722 -1 2264
+Encoding: 1114297 -1 2264
 Width: 1052
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90230,7 +90230,7 @@ Refer: 2245 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: longs_h
-Encoding: 65723 -1 2265
+Encoding: 1114298 -1 2265
 Width: 791
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90242,7 +90242,7 @@ Refer: 2251 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: longs_s
-Encoding: 65724 -1 2266
+Encoding: 1114299 -1 2266
 Width: 614
 GlyphClass: 3
 Flags: W
@@ -90253,7 +90253,7 @@ Refer: 496 383 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: f_h
-Encoding: 65725 -1 2267
+Encoding: 1114300 -1 2267
 Width: 800
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90296,7 +90296,7 @@ Refer: 287 104 N 1 0 0 1 289 0 2
 EndChar
 
 StartChar: f_k
-Encoding: 65726 -1 2268
+Encoding: 1114301 -1 2268
 Width: 790
 GlyphClass: 3
 UnlinkRmOvrlpSave: 1
@@ -90339,7 +90339,7 @@ Refer: 290 107 N 1 0 0 1 300 0 2
 EndChar
 
 StartChar: uni0185
-Encoding: 65727 -1 2269
+Encoding: 1114302 -1 2269
 Width: 0
 VWidth: 0
 Flags: W
@@ -90348,7 +90348,7 @@ Colour: 110000
 EndChar
 
 StartChar: uni0196
-Encoding: 65728 -1 2270
+Encoding: 1114303 -1 2270
 Width: 0
 VWidth: 0
 Flags: W
@@ -90357,7 +90357,7 @@ Colour: 110000
 EndChar
 
 StartChar: uni0234
-Encoding: 65729 -1 2271
+Encoding: 1114304 -1 2271
 Width: 0
 VWidth: 0
 Flags: W
@@ -90366,7 +90366,7 @@ Colour: 110000
 EndChar
 
 StartChar: uni0180
-Encoding: 65730 -1 2272
+Encoding: 1114305 -1 2272
 Width: 0
 VWidth: 0
 Flags: W
@@ -90375,7 +90375,7 @@ Colour: 120000
 EndChar
 
 StartChar: uni019A
-Encoding: 65731 -1 2273
+Encoding: 1114306 -1 2273
 Width: 0
 VWidth: 0
 Flags: W

--- a/sources/LibertinusSerifDisplay-Regular.sfd
+++ b/sources/LibertinusSerifDisplay-Regular.sfd
@@ -82,7 +82,7 @@ KernClass2: 21 21 "'kern' Kerning 1"
  161 c e o q ccedilla eogonek oe ohorn uni01DD alpha omicron sigma phi uni03F2 uni03F5 uni0435 uni043E uni0441 uni0454 uni04D9 uni04E9 uni1E19 uni1E1B uni1EB9 uni1ECD
  205 a d aacute ae eacute oacute oslash aogonek cacute edotaccent omacron uni022F alphatonos rho omicrontonos phi1 uni03F1 uni0430 uni0437 uni0444 uni044D uni044F uni04D5 uni1E0F uni1EA1 uni1F71 uni1F73 uni1F79
  141 g m n p r s z uni03BC uni03F0 uni0432 uni0433 uni0438 uni043A uni043C uni043D uni043F uni0440 uni0445 uni0446 uni0448 uni0449 uni045A uni045F
- 78 parenright bracketright braceright backslash parenright.sc bracketright.sc braceright.sc
+ 88 parenright bracketright braceright backslash parenright.sc bracketright.sc braceright.sc
  35 J j Jcircumflex jcircumflex uni0458
  259 plus hyphen less equal greater asciitilde guillemotleft uni00AD periodcentered guillemotright divide uni2010 uni2011 figuredash endash emdash uni2015 guilsinglleft guilsinglright guillemotleft.sc guillemotright.sc guilsinglleft.sc guilsinglright.sc hyphen.cap
  71 exclam question exclamdbl uni203D uni2047 uni2048 uni2049 exclamdown.sc


### PR DESCRIPTION
“But they *were* normalized!” I hear you say.

I thought so too.

There are two separate changes here, both of which I have questions about that should be answered before I merge this.

1. When I inherited this project in July, I could open the font files in FontForge, save them, run the normalizer, and everything would be clean. Now that is not the case, and I don't understand why. I'm still using FontForge 20200314, so that hasn't changed. My distro did recompile it on August 30th (against new GTK libraries I think) but I can't find any reason this should be happening. Commit fca3f1e is the result of opening every SFD file, saving it, closing it, and re-running the normalizer. @ctrlcctrlv maybe you have an idea what is causing that particular set of changes? Is this something I should add to [sfdnormalize](https://github.com/alerque/sfdnormalize)? Or are these legitimate changes, in which case is the normalizer's current enforcement of `SplineFontDB: 3.0` something I should bump to `SplineFontDB: 3.2`?

   *Edit:* Clearly this change is **wrong** because the fonts don't compile with this commit in place! But I don't understand why and it would be nice to know what's going on with FontForge.

2. Some of the font sources were encoded as `UnicodeBmp`, others as `UnicodeFull`. For the life of me I don't see any rhyme or reason why. I first got tripped up on this trying to grep for what fonts included a glyph with the intent of automating a change, but it threw me off to have the encoding different between fonts. @khaledhosny perhaps you can speak to this; besides the perhaps unnecessarily large encoding slot numbers in some cases is there any reason not to proceed with c009d21 and encode all the sources as `UnicodeFull`? 