### PR TITLE
Add ‘uni0453.ital’ and enable support for Macedonian italics

### DIFF
--- a/FONTLOG.txt
+++ b/FONTLOG.txt
@@ -51,6 +51,8 @@ unreleased (GIT) <Libertinus> Version HEAD
 - Remove bogus glyphs encoded as subscripts from Display and Serif Semibold
 - Drop inappropriate kerning classes from ₘ U+2098 and ₙ U+2099
 - Zero out kerns between super/subscript glyphs
+- Add glyph for U+0453 to Cyrillic Italic styles
+- Enable support for Macedonian localized Italics
 
 14 October 2020 (Caleb Maclennan) <Libertinus> Version 7.020
 - Fix name tables broken in 7.010 that associate styles in the Serif family

--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -279,7 +279,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "acute" "'mark' Mark Positioning lookup 5" "above" "'mark' Mark Positioning lookup 4" "top_punkt" "'mark' Mark Positioning lookup 4" "below" "'mark' Mark Positioning lookup 3" "cedilla" "'mark' Mark Positioning lookup 2" "ogonek" "'mark' Mark Positioning lookup 1" "middle" "'mark' Mark Positioning in Hebrew lookup 0"
-BeginChars: 1114389 2458
+BeginChars: 1114390 2458
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -73326,6 +73326,19 @@ SplineSet
  341 556 327 538 314 538 c 2
 EndSplineSet
 Refer: 636 618 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni0453.ital
+Encoding: 1114389 -1 2453
+Width: 268
+GlyphClass: 2
+Flags: W
+AnchorPoint: "above" 261 645 basechar 0
+AnchorPoint: "below" 110 -114 basechar 0
+LayerCount: 2
+Fore
+Refer: 670 769 N 1 0 0 1 375.466 94 2
+Refer: 2449 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: q.sc.u

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -287,7 +287,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "top_punkt" "'mark' Top Punkt" "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 1114407 1900
+BeginChars: 1114408 1900
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -54892,6 +54892,17 @@ SplineSet
  385 558 370 538 356 538 c 2
 EndSplineSet
 Refer: 359 305 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni0453.ital
+Encoding: 1114407 -1 1888
+Width: 342
+VWidth: 0
+Flags: W
+LayerCount: 2
+Fore
+Refer: 454 769 N 1 0 0 1 500.966 143 2
+Refer: 1840 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni03D0

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -306,7 +306,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 1114402 2395
+BeginChars: 1114403 2395
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -70820,6 +70820,16 @@ SplineSet
  762.2 556 747.5 538 734.5 538 c 2
 EndSplineSet
 Refer: 97 1096 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni0453.ital
+Encoding: 1114402 -1 2380
+Width: 268
+Flags: MW
+LayerCount: 2
+Fore
+Refer: 672 769 N 1 0 0 1 367.366 94 2
+Refer: 2307 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uniE01C

--- a/sources/LibertinusSerif-SemiboldItalic.sfd
+++ b/sources/LibertinusSerif-SemiboldItalic.sfd
@@ -208,7 +208,7 @@ Grid
  766 430 l 25
 EndSplineSet
 AnchorClass2: "top_punkt" "'mark' Top Punkt" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR" "right" "'mark' Right"
-BeginChars: 1114414 2373
+BeginChars: 1114415 2373
 
 StartChar: space
 Encoding: 32 32 0
@@ -71860,6 +71860,17 @@ SplineSet
  68 33 l 2
  102 33 115 48 121 76 c 2
 EndSplineSet
+EndChar
+
+StartChar: uni0453.ital
+Encoding: 1114414 -1 2359
+Width: 0
+VWidth: 0
+Flags: W
+LayerCount: 2
+Fore
+Refer: 658 769 N 1 0 0 1 382.911 100 2
+Refer: 2337 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: a.scalt

--- a/sources/features/gsub.fea
+++ b/sources/features/gsub.fea
@@ -5,6 +5,7 @@
 languagesystem DFLT dflt;
 languagesystem cyrl dflt;
 languagesystem cyrl SRB;
+languagesystem cyrl MKD;
 languagesystem grek dflt;
 languagesystem hebr dflt;
 languagesystem latn AZE;

--- a/sources/features/locl.fea
+++ b/sources/features/locl.fea
@@ -5,6 +5,7 @@ lookup locl_cyrillic {
   sub uni0434 by uni0434.ital;
   sub uni043F by uni043F.ital;
   sub uni0442 by uni0442.ital;
+  sub uni0453 by uni0453.ital;
 #endif
 } locl_cyrillic;
 

--- a/sources/features/locl.fea
+++ b/sources/features/locl.fea
@@ -17,6 +17,8 @@ feature locl {
   script cyrl;
     language SRB exclude_dflt;
       lookup locl_cyrillic;
+    language MKD exclude_dflt;
+      lookup locl_cyrillic;
 
   script latn;
     language FIN exclude_dflt;


### PR DESCRIPTION
Fixes #394.  See also #29.

![Comparison](https://user-images.githubusercontent.com/7765538/97181796-fa33ca80-179b-11eb-98bb-e88e917e9630.png)

