### PR TITLE
Normalize sources, rebuild with updated tooling

### DIFF
--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -279,7 +279,7 @@ Grid
  -113 550 l 1025
 EndSplineSet
 AnchorClass2: "acute" "'mark' Mark Positioning lookup 5" "above" "'mark' Mark Positioning lookup 4" "top_punkt" "'mark' Mark Positioning lookup 4" "below" "'mark' Mark Positioning lookup 3" "cedilla" "'mark' Mark Positioning lookup 2" "ogonek" "'mark' Mark Positioning lookup 1" "middle" "'mark' Mark Positioning in Hebrew lookup 0"
-BeginChars: 1114390 2458
+BeginChars: 1114390 2459
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -73328,19 +73328,6 @@ EndSplineSet
 Refer: 636 618 N 1 0 0 1 0 0 2
 EndChar
 
-StartChar: uni0453.ital
-Encoding: 1114389 -1 2453
-Width: 268
-GlyphClass: 2
-Flags: W
-AnchorPoint: "above" 261 645 basechar 0
-AnchorPoint: "below" 110 -114 basechar 0
-LayerCount: 2
-Fore
-Refer: 670 769 N 1 0 0 1 375.466 94 2
-Refer: 2449 -1 N 1 0 0 1 0 0 3
-EndChar
-
 StartChar: q.sc.u
 Encoding: 1114386 -1 2450
 Width: 570
@@ -73439,15 +73426,17 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: uni0249
-Encoding: 585 585 2453
-Width: 310
+StartChar: uni0453.ital
+Encoding: 1114389 -1 2453
+Width: 268
 GlyphClass: 2
 Flags: W
+AnchorPoint: "above" 261 645 basechar 0
+AnchorPoint: "below" 110 -114 basechar 0
 LayerCount: 2
 Fore
-Refer: 664 729 N 1 0 0 1 -5 0 2
-Refer: 2451 -1 N 1 0 0 1 0 0 2
+Refer: 670 769 N 1 0 0 1 375.466 94 2
+Refer: 2449 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni200D
@@ -73501,6 +73490,17 @@ SplineSet
 EndSplineSet
 Refer: 308 124 N 1 0 0 1 140.471 0 2
 Refer: 18 58 N 1 0 0 1 -9.52887 0 2
+EndChar
+
+StartChar: uni0249
+Encoding: 585 585 2458
+Width: 310
+GlyphClass: 2
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 729 N 1 0 0 1 -5 0 2
+Refer: 2451 -1 N 1 0 0 1 0 0 2
 EndChar
 EndChars
 EndSplineFont

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -287,7 +287,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "top_punkt" "'mark' Top Punkt" "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 1114408 1900
+BeginChars: 1114408 1901
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -54894,17 +54894,6 @@ EndSplineSet
 Refer: 359 305 N 1 0 0 1 0 0 2
 EndChar
 
-StartChar: uni0453.ital
-Encoding: 1114407 -1 1888
-Width: 342
-VWidth: 0
-Flags: W
-LayerCount: 2
-Fore
-Refer: 454 769 N 1 0 0 1 500.966 143 2
-Refer: 1840 -1 N 1 0 0 1 0 0 3
-EndChar
-
 StartChar: uni03D0
 Encoding: 976 976 1841
 Width: 559
@@ -56095,24 +56084,15 @@ LayerCount: 2
 Colour: 110000
 EndChar
 
-StartChar: uniA78A
-Encoding: 42890 42890 1888
-Width: 358
+StartChar: uni0453.ital
+Encoding: 1114407 -1 1888
+Width: 342
+VWidth: 0
 Flags: W
 LayerCount: 2
 Fore
-SplineSet
-347.399414062 198 m 1
- 335.5 142 l 1
- 85.7998046875 142 l 1
- 97.7001953125 198 l 1
- 347.399414062 198 l 1
-374 323 m 1
- 361.899414062 266 l 1
- 112.099609375 266 l 1
- 124.299804688 323 l 1
- 374 323 l 1
-EndSplineSet
+Refer: 454 769 N 1 0 0 1 500.966 143 2
+Refer: 1840 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uniA71D
@@ -56245,6 +56225,26 @@ LayerCount: 2
 Fore
 Refer: 457 775 N 1 0 0 1 540.07 188 2
 Refer: 205 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uniA78A
+Encoding: 42890 42890 1900
+Width: 358
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+347.399414062 198 m 1
+ 335.5 142 l 1
+ 85.7998046875 142 l 1
+ 97.7001953125 198 l 1
+ 347.399414062 198 l 1
+374 323 m 1
+ 361.899414062 266 l 1
+ 112.099609375 266 l 1
+ 124.299804688 323 l 1
+ 374 323 l 1
+EndSplineSet
 EndChar
 EndChars
 EndSplineFont

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -306,7 +306,7 @@ Grid
  -463 550 l 1025
 EndSplineSet
 AnchorClass2: "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
-BeginChars: 1114403 2395
+BeginChars: 1114403 2396
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -70822,16 +70822,6 @@ EndSplineSet
 Refer: 97 1096 N 1 0 0 1 0 0 2
 EndChar
 
-StartChar: uni0453.ital
-Encoding: 1114402 -1 2380
-Width: 268
-Flags: MW
-LayerCount: 2
-Fore
-Refer: 672 769 N 1 0 0 1 367.366 94 2
-Refer: 2307 -1 N 1 0 0 1 0 0 3
-EndChar
-
 StartChar: uniE01C
 Encoding: 1114350 -1 2310
 Width: 255
@@ -72938,24 +72928,14 @@ LayerCount: 2
 Colour: 110000
 EndChar
 
-StartChar: uniA78A
-Encoding: 42890 42890 2380
-Width: 333
-Flags: W
+StartChar: uni0453.ital
+Encoding: 1114402 -1 2380
+Width: 268
+Flags: MW
 LayerCount: 2
 Fore
-SplineSet
-326 193 m 1
- 317 144 l 1
- 71 144 l 1
- 80 193 l 1
- 326 193 l 1
-348 318 m 1
- 339 269 l 1
- 93 269 l 1
- 102 318 l 1
- 348 318 l 1
-EndSplineSet
+Refer: 672 769 N 1 0 0 1 367.366 94 2
+Refer: 2307 -1 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uniA71D
@@ -73126,6 +73106,26 @@ SplineSet
  484 652 l 1
 EndSplineSet
 Refer: 18 58 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uniA78A
+Encoding: 42890 42890 2395
+Width: 333
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+326 193 m 1
+ 317 144 l 1
+ 71 144 l 1
+ 80 193 l 1
+ 326 193 l 1
+348 318 m 1
+ 339 269 l 1
+ 93 269 l 1
+ 102 318 l 1
+ 348 318 l 1
+EndSplineSet
 EndChar
 EndChars
 EndSplineFont

--- a/sources/LibertinusSerif-SemiboldItalic.sfd
+++ b/sources/LibertinusSerif-SemiboldItalic.sfd
@@ -208,7 +208,7 @@ Grid
  766 430 l 25
 EndSplineSet
 AnchorClass2: "top_punkt" "'mark' Top Punkt" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR" "right" "'mark' Right"
-BeginChars: 1114415 2373
+BeginChars: 1114415 2374
 
 StartChar: space
 Encoding: 32 32 0
@@ -71862,17 +71862,6 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: uni0453.ital
-Encoding: 1114414 -1 2359
-Width: 0
-VWidth: 0
-Flags: W
-LayerCount: 2
-Fore
-Refer: 658 769 N 1 0 0 1 382.911 100 2
-Refer: 2337 -1 N 1 0 0 1 0 0 2
-EndChar
-
 StartChar: a.scalt
 Encoding: 1114394 -1 2338
 Width: 591
@@ -72569,24 +72558,15 @@ LayerCount: 2
 Colour: 110000
 EndChar
 
-StartChar: uniA78A
-Encoding: 42890 42890 2359
-Width: 374
+StartChar: uni0453.ital
+Encoding: 1114414 -1 2359
+Width: 0
+VWidth: 0
 Flags: W
 LayerCount: 2
 Fore
-SplineSet
-380.666992188 198 m 1
- 368.666992188 142 l 1
- 67 142 l 1
- 79 198 l 1
- 380.666992188 198 l 1
-405.666992188 323 m 1
- 393.666992188 266 l 1
- 93 266 l 1
- 104 323 l 1
- 405.666992188 323 l 1
-EndSplineSet
+Refer: 658 769 N 1 0 0 1 382.911 100 2
+Refer: 2337 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniA71B
@@ -72739,6 +72719,26 @@ SplineSet
 EndSplineSet
 Refer: 26 58 N 1 0 0 1 -16.25 0 2
 Refer: 92 124 N 1 0 0 1 137.75 0 2
+EndChar
+
+StartChar: uniA78A
+Encoding: 42890 42890 2373
+Width: 374
+Flags: W
+LayerCount: 2
+Fore
+SplineSet
+380.666992188 198 m 1
+ 368.666992188 142 l 1
+ 67 142 l 1
+ 79 198 l 1
+ 380.666992188 198 l 1
+405.666992188 323 m 1
+ 393.666992188 266 l 1
+ 93 266 l 1
+ 104 323 l 1
+ 405.666992188 323 l 1
+EndSplineSet
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
Round tripping through FontForge turned up some differences for me. I don't quite understand why.

More notably, the latest Fontship release that this will currently build on (v0.7.0) includes updated `fontmake` and `gftools` which handle a few things differently.