### PR TITLE
Additional sizes of angle brackets from STIX

### DIFF
--- a/sources/LibertinusMath-Regular.sfd
+++ b/sources/LibertinusMath-Regular.sfd
@@ -617,7 +617,7 @@ Grid
   Named: "Top Accent"
 EndSplineSet
 AnchorClass2: "aboveMark" "'mkmk' Mark to Mark-1" "right" "'mark' Right" "komb_OR" "'mark' Komb OR" "above" "'mark' Above" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle"
-BeginChars: 1114787 4294
+BeginChars: 1114819 4326
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -103510,18 +103510,18 @@ Width: 359
 GlyphClass: 2
 Flags: MW
 IsExtendedShape: 1
-GlyphVariantsVertical: uni27E8 uni27E8.size1 uni27E8.size2 uni27E8.size3 uni27E8.size4
+GlyphVariantsVertical: uni27E8 uni27E8.size1 uni27E8.size2 uni27E8.size3 uni27E8.size4 uni27E8.size5 uni27E8.size6 uni27E8.size7 uni27E8.size8 uni27E8.size9 uni27E8.size10 uni27E8.size11 uni27E8.size12
 LayerCount: 2
 Fore
 SplineSet
-309 702 m 1
- 112 240 l 1
- 308 -217 l 1
- 255 -217 l 1
- 45 230 l 1
- 45 250 l 1
- 256 702 l 1
- 309 702 l 1
+112 270 m 1
+ 299 -196 l 1
+ 262 -196 l 1
+ 40 260 l 1
+ 40 280 l 1
+ 262 736 l 1
+ 299 736 l 1
+ 112 270 l 1
 EndSplineSet
 EndChar
 
@@ -103531,19 +103531,10 @@ Width: 359
 GlyphClass: 2
 Flags: MW
 IsExtendedShape: 1
-GlyphVariantsVertical: uni27E9 uni27E9.size1 uni27E9.size2 uni27E9.size3 uni27E9.size4
+GlyphVariantsVertical: uni27E9 uni27E9.size1 uni27E9.size2 uni27E9.size3 uni27E9.size4 uni27E9.size5 uni27E9.size6 uni27E9.size7 uni27E9.size8 uni27E9.size9 uni27E9.size10 uni27E9.size11 uni27E9.size12
 LayerCount: 2
 Fore
-SplineSet
-247 240 m 1
- 50 702 l 1
- 103 702 l 1
- 314 250 l 1
- 314 230 l 1
- 104 -217 l 1
- 51 -217 l 1
- 247 240 l 1
-EndSplineSet
+Refer: 2478 10216 N -1 0 0 1 339 0 2
 EndChar
 
 StartChar: uni2C6E
@@ -150929,77 +150920,77 @@ EndChar
 
 StartChar: uni27E8.size1
 Encoding: 1114629 -1 3892
-Width: 408
+Width: 369
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
 SplineSet
-353 852 m 1
- 129 270 l 1
- 352 -306 l 1
- 307 -306 l 1
- 50 258 l 1
- 50 283 l 1
- 309 852 l 1
- 353 852 l 1
+119 270 m 1
+ 330 -323 l 1
+ 291 -323 l 1
+ 43 259 l 1
+ 43 281 l 1
+ 291 863 l 1
+ 330 863 l 1
+ 119 270 l 1
 EndSplineSet
 EndChar
 
 StartChar: uni27E8.size2
 Encoding: 1114630 -1 3893
+Width: 397
+Flags: MW
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+125 270 m 1
+ 358 -443 l 1
+ 319 -443 l 1
+ 46 259 l 1
+ 46 281 l 1
+ 319 983 l 1
+ 358 983 l 1
+ 125 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size3
+Encoding: 1114631 -1 3894
+Width: 424
+Flags: MW
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+131 270 m 1
+ 387 -563 l 1
+ 346 -563 l 1
+ 49 258 l 1
+ 49 282 l 1
+ 346 1103 l 1
+ 387 1103 l 1
+ 131 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size4
+Encoding: 1114632 -1 3895
 Width: 452
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
 SplineSet
-392 971 m 1
- 142 267 l 1
- 390 -429 l 1
- 344 -429 l 1
- 55 253 l 1
- 55 283 l 1
- 347 971 l 1
- 392 971 l 1
-EndSplineSet
-EndChar
-
-StartChar: uni27E8.size3
-Encoding: 1114631 -1 3894
-Width: 488
-Flags: MW
-IsExtendedShape: 1
-LayerCount: 2
-Fore
-SplineSet
-423 1093 m 1
- 151 266 l 1
- 421 -550 l 1
- 376 -550 l 1
- 60 250 l 1
- 60 285 l 1
- 379 1093 l 1
- 423 1093 l 1
-EndSplineSet
-EndChar
-
-StartChar: uni27E8.size4
-Encoding: 1114632 -1 3895
-Width: 546
-Flags: MW
-IsExtendedShape: 1
-LayerCount: 2
-Fore
-SplineSet
-478 1214 m 1
- 164 265 l 1
- 475 -671 l 1
- 428 -671 l 1
- 63 247 l 1
- 63 287 l 1
- 431 1214 l 1
- 478 1214 l 1
+137 270 m 1
+ 416 -683 l 1
+ 373 -683 l 1
+ 52 257 l 1
+ 52 283 l 1
+ 373 1223 l 1
+ 416 1223 l 1
+ 137 270 l 1
 EndSplineSet
 EndChar
 
@@ -151505,294 +151496,126 @@ EndChar
 
 StartChar: uni27E9.size1
 Encoding: 1114653 -1 3916
-Width: 408
+Width: 369
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-279 270 m 1
- 55 852 l 1
- 99 852 l 1
- 358 283 l 1
- 358 258 l 1
- 101 -306 l 1
- 56 -306 l 1
- 279 270 l 1
-EndSplineSet
+Refer: 3892 -1 N -1 0 0 1 369 0 2
 EndChar
 
 StartChar: uni27E9.size2
 Encoding: 1114654 -1 3917
+Width: 397
+Flags: MW
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 3893 -1 N -1 0 0 1 397 0 2
+EndChar
+
+StartChar: uni27E9.size3
+Encoding: 1114655 -1 3918
+Width: 424
+Flags: MW
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 3894 -1 N -1 0 0 1 424 0 2
+EndChar
+
+StartChar: uni27E9.size4
+Encoding: 1114656 -1 3919
 Width: 452
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-310 267 m 1
- 60 971 l 1
- 105 971 l 1
- 397 283 l 1
- 397 253 l 1
- 108 -429 l 1
- 62 -429 l 1
- 310 267 l 1
-EndSplineSet
-EndChar
-
-StartChar: uni27E9.size3
-Encoding: 1114655 -1 3918
-Width: 488
-Flags: MW
-IsExtendedShape: 1
-LayerCount: 2
-Fore
-SplineSet
-337 266 m 1
- 65 1093 l 1
- 109 1093 l 1
- 428 285 l 1
- 428 250 l 1
- 112 -550 l 1
- 67 -550 l 1
- 337 266 l 1
-EndSplineSet
-EndChar
-
-StartChar: uni27E9.size4
-Encoding: 1114656 -1 3919
-Width: 546
-Flags: MW
-IsExtendedShape: 1
-LayerCount: 2
-Fore
-SplineSet
-382 265 m 1
- 68 1214 l 1
- 115 1214 l 1
- 483 287 l 1
- 483 247 l 1
- 118 -671 l 1
- 71 -671 l 1
- 382 265 l 1
-EndSplineSet
+Refer: 3895 -1 N -1 0 0 1 452 0 2
 EndChar
 
 StartChar: uni27EA.size1
 Encoding: 1114657 -1 3920
-Width: 666
+Width: 594
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-611 852 m 1
- 387 270 l 1
- 610 -306 l 1
- 565 -306 l 1
- 308 258 l 1
- 308 283 l 1
- 567 852 l 1
- 611 852 l 1
-353 852 m 1
- 129 270 l 1
- 352 -306 l 1
- 307 -306 l 1
- 50 258 l 1
- 50 283 l 1
- 309 852 l 1
- 353 852 l 1
-EndSplineSet
+Refer: 3892 -1 N 1 0 0 1 225 0 2
+Refer: 3892 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni27EA.size2
 Encoding: 1114658 -1 3921
-Width: 744
+Width: 636
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-392 971 m 1
- 142 267 l 1
- 390 -429 l 1
- 344 -429 l 1
- 55 253 l 1
- 55 283 l 1
- 347 971 l 1
- 392 971 l 1
-684 971 m 1
- 434 267 l 1
- 682 -429 l 1
- 636 -429 l 1
- 347 253 l 1
- 347 283 l 1
- 639 971 l 1
- 684 971 l 1
-EndSplineSet
+Refer: 3893 -1 N 1 0 0 1 239 0 2
+Refer: 3893 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni27EA.size3
 Encoding: 1114659 -1 3922
-Width: 806
+Width: 678
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-423 1093 m 1
- 151 266 l 1
- 421 -550 l 1
- 376 -550 l 1
- 60 250 l 1
- 60 285 l 1
- 379 1093 l 1
- 423 1093 l 1
-741 1093 m 1
- 469 266 l 1
- 739 -550 l 1
- 694 -550 l 1
- 378 250 l 1
- 378 285 l 1
- 697 1093 l 1
- 741 1093 l 1
-EndSplineSet
+Refer: 3894 -1 N 1 0 0 1 253 0 2
+Refer: 3894 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni27EA.size4
 Encoding: 1114660 -1 3923
-Width: 913
+Width: 720
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-478 1214 m 1
- 164 265 l 1
- 475 -671 l 1
- 428 -671 l 1
- 63 247 l 1
- 63 287 l 1
- 431 1214 l 1
- 478 1214 l 1
-845 1214 m 1
- 531 265 l 1
- 842 -671 l 1
- 795 -671 l 1
- 430 247 l 1
- 430 287 l 1
- 798 1214 l 1
- 845 1214 l 1
-EndSplineSet
+Refer: 3895 -1 N 1 0 0 1 267 0 2
+Refer: 3895 -1 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni27EB.size1
 Encoding: 1114661 -1 3924
-Width: 666
+Width: 594
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-279 270 m 1
- 55 852 l 1
- 99 852 l 1
- 358 283 l 1
- 358 258 l 1
- 101 -306 l 1
- 56 -306 l 1
- 279 270 l 1
-537 270 m 1
- 313 852 l 1
- 357 852 l 1
- 616 283 l 1
- 616 258 l 1
- 359 -306 l 1
- 314 -306 l 1
- 537 270 l 1
-EndSplineSet
+Refer: 3920 -1 N -1 0 0 1 594 0 2
 EndChar
 
 StartChar: uni27EB.size2
 Encoding: 1114662 -1 3925
-Width: 744
+Width: 636
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-602 267 m 1
- 352 971 l 1
- 397 971 l 1
- 689 283 l 1
- 689 253 l 1
- 400 -429 l 1
- 354 -429 l 1
- 602 267 l 1
-310 267 m 1
- 60 971 l 1
- 105 971 l 1
- 397 283 l 1
- 397 253 l 1
- 108 -429 l 1
- 62 -429 l 1
- 310 267 l 1
-EndSplineSet
+Refer: 3921 -1 N -1 0 0 1 636 0 2
 EndChar
 
 StartChar: uni27EB.size3
 Encoding: 1114663 -1 3926
-Width: 806
+Width: 678
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-655 266 m 1
- 383 1093 l 1
- 427 1093 l 1
- 746 285 l 1
- 746 250 l 1
- 430 -550 l 1
- 385 -550 l 1
- 655 266 l 1
-337 266 m 1
- 65 1093 l 1
- 109 1093 l 1
- 428 285 l 1
- 428 250 l 1
- 112 -550 l 1
- 67 -550 l 1
- 337 266 l 1
-EndSplineSet
+Refer: 3922 -1 N -1 0 0 1 678 0 2
 EndChar
 
 StartChar: uni27EB.size4
 Encoding: 1114664 -1 3927
-Width: 913
+Width: 720
 Flags: MW
 IsExtendedShape: 1
 LayerCount: 2
 Fore
-SplineSet
-749 265 m 1
- 435 1214 l 1
- 482 1214 l 1
- 850 287 l 1
- 850 247 l 1
- 485 -671 l 1
- 438 -671 l 1
- 749 265 l 1
-382 265 m 1
- 68 1214 l 1
- 115 1214 l 1
- 483 287 l 1
- 483 247 l 1
- 118 -671 l 1
- 71 -671 l 1
- 382 265 l 1
-EndSplineSet
+Refer: 3923 -1 N -1 0 0 1 720 0 2
 EndChar
 
 StartChar: uni29FC
@@ -151843,60 +151666,28 @@ EndChar
 
 StartChar: uni27EA
 Encoding: 10218 10218 3930
-Width: 569
+Width: 549
 GlyphClass: 2
 Flags: W
 IsExtendedShape: 1
-GlyphVariantsVertical: uni27EA uni27EA.size1 uni27EA.size2 uni27EA.size3 uni27EA.size4
+GlyphVariantsVertical: uni27EA uni27EA.size1 uni27EA.size2 uni27EA.size3 uni27EA.size4 uni27EA.size5 uni27EA.size6 uni27EA.size7 uni27EA.size8 uni27EA.size9 uni27EA.size10 uni27EA.size11 uni27EA.size12
 LayerCount: 2
 Fore
-SplineSet
-309 732 m 1
- 112 270 l 1
- 308 -187 l 1
- 255 -187 l 1
- 45 260 l 1
- 45 280 l 1
- 256 732 l 1
- 309 732 l 1
-519 732 m 1
- 322 270 l 1
- 518 -187 l 1
- 465 -187 l 1
- 255 260 l 1
- 255 280 l 1
- 466 732 l 1
- 519 732 l 1
-EndSplineSet
+Refer: 2478 10216 N 1 0 0 1 210 0 2
+Refer: 2478 10216 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni27EB
 Encoding: 10219 10219 3931
-Width: 569
+Width: 549
 GlyphClass: 2
 Flags: W
 IsExtendedShape: 1
-GlyphVariantsVertical: uni27EB uni27EB.size1 uni27EB.size2 uni27EB.size3 uni27EB.size4
+GlyphVariantsVertical: uni27EB uni27EB.size1 uni27EB.size2 uni27EB.size3 uni27EB.size4 uni27EB.size5 uni27EB.size6 uni27EB.size7 uni27EB.size8 uni27EB.size9 uni27EB.size10 uni27EB.size11 uni27EB.size12
 LayerCount: 2
 Fore
-SplineSet
-457 270 m 1
- 260 732 l 1
- 313 732 l 1
- 524 280 l 1
- 524 260 l 1
- 314 -187 l 1
- 261 -187 l 1
- 457 270 l 1
-247 270 m 1
- 50 732 l 1
- 103 732 l 1
- 314 280 l 1
- 314 260 l 1
- 104 -187 l 1
- 51 -187 l 1
- 247 270 l 1
-EndSplineSet
+Refer: 2479 10217 N 1 0 0 1 210 0 2
+Refer: 2479 10217 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni27EC
@@ -160078,6 +159869,406 @@ Flags: W
 LayerCount: 2
 Fore
 Refer: 4277 -1 N 1 0 0 -1 0 539 2
+EndChar
+
+StartChar: uni27E8.size5
+Encoding: 1114787 -1 4294
+Width: 480
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+143 270 m 1
+ 444 -803 l 1
+ 401 -803 l 1
+ 55 257 l 1
+ 55 283 l 1
+ 401 1343 l 1
+ 444 1343 l 1
+ 143 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size6
+Encoding: 1114788 -1 4295
+Width: 508
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+149 270 m 1
+ 473 -923 l 1
+ 428 -923 l 1
+ 58 256 l 1
+ 58 284 l 1
+ 428 1463 l 1
+ 473 1463 l 1
+ 149 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size7
+Encoding: 1114789 -1 4296
+Width: 536
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+155 270 m 1
+ 502 -1043 l 1
+ 455 -1043 l 1
+ 60 255 l 1
+ 60 285 l 1
+ 455 1583 l 1
+ 502 1583 l 1
+ 155 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size8
+Encoding: 1114790 -1 4297
+Width: 564
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+161 270 m 1
+ 530 -1163 l 1
+ 483 -1163 l 1
+ 63 255 l 1
+ 63 285 l 1
+ 483 1703 l 1
+ 530 1703 l 1
+ 161 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size9
+Encoding: 1114791 -1 4298
+Width: 591
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+168 270 m 1
+ 559 -1281 l 1
+ 510 -1281 l 1
+ 66 254 l 1
+ 66 286 l 1
+ 510 1821 l 1
+ 559 1821 l 1
+ 168 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size10
+Encoding: 1114792 -1 4299
+Width: 619
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+174 270 m 1
+ 588 -1401 l 1
+ 537 -1401 l 1
+ 69 253 l 1
+ 69 287 l 1
+ 537 1941 l 1
+ 588 1941 l 1
+ 174 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size11
+Encoding: 1114793 -1 4300
+Width: 647
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+180 270 m 1
+ 616 -1521 l 1
+ 565 -1521 l 1
+ 72 253 l 1
+ 72 287 l 1
+ 565 2061 l 1
+ 616 2061 l 1
+ 180 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E8.size12
+Encoding: 1114794 -1 4301
+Width: 675
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+186 270 m 1
+ 645 -1641 l 1
+ 592 -1641 l 1
+ 75 252 l 1
+ 75 288 l 1
+ 592 2181 l 1
+ 645 2181 l 1
+ 186 270 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni27E9.size5
+Encoding: 1114795 -1 4302
+Width: 480
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4294 -1 N -1 0 0 1 480 0 2
+EndChar
+
+StartChar: uni27E9.size6
+Encoding: 1114796 -1 4303
+Width: 508
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4295 -1 N -1 0 0 1 508 0 2
+EndChar
+
+StartChar: uni27E9.size7
+Encoding: 1114797 -1 4304
+Width: 536
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4296 -1 N -1 0 0 1 536 0 2
+EndChar
+
+StartChar: uni27E9.size8
+Encoding: 1114798 -1 4305
+Width: 564
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4297 -1 N -1 0 0 1 564 0 2
+EndChar
+
+StartChar: uni27E9.size9
+Encoding: 1114799 -1 4306
+Width: 591
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4298 -1 N -1 0 0 1 591 0 2
+EndChar
+
+StartChar: uni27E9.size10
+Encoding: 1114800 -1 4307
+Width: 619
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4299 -1 N -1 0 0 1 619 0 2
+EndChar
+
+StartChar: uni27E9.size11
+Encoding: 1114801 -1 4308
+Width: 647
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4300 -1 N -1 0 0 1 647 0 2
+EndChar
+
+StartChar: uni27E9.size12
+Encoding: 1114802 -1 4309
+Width: 675
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4301 -1 N -1 0 0 1 675 0 2
+EndChar
+
+StartChar: uni27EA.size5
+Encoding: 1114803 -1 4310
+Width: 761
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4294 -1 N 1 0 0 1 281 0 2
+Refer: 4294 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size6
+Encoding: 1114804 -1 4311
+Width: 803
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4295 -1 N 1 0 0 1 295 0 2
+Refer: 4295 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size7
+Encoding: 1114805 -1 4312
+Width: 845
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4296 -1 N 1 0 0 1 310 0 2
+Refer: 4296 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size8
+Encoding: 1114806 -1 4313
+Width: 887
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4297 -1 N 1 0 0 1 324 0 2
+Refer: 4297 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size9
+Encoding: 1114807 -1 4314
+Width: 929
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4298 -1 N 1 0 0 1 338 0 2
+Refer: 4298 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size10
+Encoding: 1114808 -1 4315
+Width: 971
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4299 -1 N 1 0 0 1 352 0 2
+Refer: 4299 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size11
+Encoding: 1114809 -1 4316
+Width: 1013
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4300 -1 N 1 0 0 1 366 0 2
+Refer: 4300 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EA.size12
+Encoding: 1114810 -1 4317
+Width: 1055
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4301 -1 N 1 0 0 1 380 0 2
+Refer: 4301 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni27EB.size5
+Encoding: 1114811 -1 4318
+Width: 761
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4310 -1 N -1 0 0 1 761 0 2
+EndChar
+
+StartChar: uni27EB.size6
+Encoding: 1114812 -1 4319
+Width: 803
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4311 -1 N -1 0 0 1 803 0 2
+EndChar
+
+StartChar: uni27EB.size7
+Encoding: 1114813 -1 4320
+Width: 845
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4312 -1 N -1 0 0 1 845 0 2
+EndChar
+
+StartChar: uni27EB.size8
+Encoding: 1114814 -1 4321
+Width: 887
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4313 -1 N -1 0 0 1 887 0 2
+EndChar
+
+StartChar: uni27EB.size9
+Encoding: 1114815 -1 4322
+Width: 929
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4314 -1 N -1 0 0 1 929 0 2
+EndChar
+
+StartChar: uni27EB.size10
+Encoding: 1114816 -1 4323
+Width: 971
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4315 -1 N -1 0 0 1 971 0 2
+EndChar
+
+StartChar: uni27EB.size11
+Encoding: 1114817 -1 4324
+Width: 1013
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4316 -1 N -1 0 0 1 1013 0 2
+EndChar
+
+StartChar: uni27EB.size12
+Encoding: 1114818 -1 4325
+Width: 1055
+Flags: W
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4317 -1 N -1 0 0 1 1055 0 2
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
Imported sizes 5-12 of angle brackets and double angle brackets from STIX. Also replaced the regular-sized angle brackets to match the others.

![libertinus_brackets](https://user-images.githubusercontent.com/7095181/103231386-f0634a80-4937-11eb-8c25-c1edc9728bc0.png)

Fixes #412.