### PR TITLE
Add slanted integrals

### DIFF
--- a/sources/LibertinusMath-Regular.sfd
+++ b/sources/LibertinusMath-Regular.sfd
@@ -617,7 +617,7 @@ Grid
   Named: "Top Accent"
 EndSplineSet
 AnchorClass2: "aboveMark" "'mkmk' Mark to Mark-1" "right" "'mark' Right" "komb_OR" "'mark' Komb OR" "above" "'mark' Above" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle"
-BeginChars: 1114819 4326
+BeginChars: 1114839 4346
 
 StartChar: exclam
 Encoding: 33 33 0
@@ -92391,7 +92391,6 @@ Width: 500
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
 Flags: MW
-ItalicCorrection: 150
 IsExtendedShape: 1
 GlyphVariantsVertical: uni222E uni222E.size1
 LayerCount: 2
@@ -131869,7 +131868,7 @@ StartChar: integral.size1
 Encoding: 1114441 -1 3240
 Width: 694
 Flags: MW
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -131902,7 +131901,7 @@ StartChar: uni222C.size1
 Encoding: 1114442 -1 3241
 Width: 1034
 Flags: MW
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -131914,7 +131913,7 @@ StartChar: uni222D.size1
 Encoding: 1114443 -1 3242
 Width: 1374
 Flags: MW
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -131924,16 +131923,16 @@ EndChar
 
 StartChar: uni222E.size1
 Encoding: 1114444 -1 3243
-Width: 697
+Width: 736
 UnlinkRmOvrlpSave: 1
 Flags: MW
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Back
 SplineSet
-850 562 m 25
- -1058 562 l 1049
+802 562 m 25
+ -1106 562 l 1049
 EndSplineSet
 Fore
 SplineSet
@@ -134455,7 +134454,7 @@ StartChar: uni2A0C.size1
 Encoding: 1114546 -1 3372
 Width: 1714
 Flags: MW
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -152556,7 +152555,6 @@ Width: 740
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 150
 IsExtendedShape: 1
 GlyphVariantsVertical: uni222F uni222F.size1
 LayerCount: 2
@@ -152586,7 +152584,6 @@ Width: 980
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 150
 IsExtendedShape: 1
 GlyphVariantsVertical: uni2230 uni2230.size1
 LayerCount: 2
@@ -152612,10 +152609,10 @@ EndChar
 
 StartChar: uni222F.size1
 Encoding: 1114691 -1 3976
-Width: 1037
+Width: 1076
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -152650,10 +152647,10 @@ EndChar
 
 StartChar: uni2230.size1
 Encoding: 1114692 -1 3977
-Width: 1377
+Width: 1416
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 180
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -152692,7 +152689,6 @@ Width: 571
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 231
 IsExtendedShape: 1
 GlyphVariantsVertical: uni2232 uni2232.size1
 LayerCount: 2
@@ -152719,7 +152715,6 @@ Width: 571
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 231
 IsExtendedShape: 1
 GlyphVariantsVertical: uni2233 uni2233.size1
 LayerCount: 2
@@ -152746,7 +152741,6 @@ Width: 573
 GlyphClass: 2
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 231
 IsExtendedShape: 1
 GlyphVariantsVertical: uni2231 uni2231.size1
 LayerCount: 2
@@ -152769,7 +152763,7 @@ Encoding: 1114693 -1 3981
 Width: 796
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 279
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -152805,7 +152799,7 @@ Encoding: 1114694 -1 3982
 Width: 796
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 279
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -152843,7 +152837,7 @@ Encoding: 1114695 -1 3983
 Width: 796
 UnlinkRmOvrlpSave: 1
 Flags: W
-ItalicCorrection: 279
+ItalicCorrection: 250
 IsExtendedShape: 1
 LayerCount: 2
 Fore
@@ -160269,6 +160263,516 @@ IsExtendedShape: 1
 LayerCount: 2
 Fore
 Refer: 4317 -1 N -1 0 0 1 1055 0 2
+EndChar
+
+StartChar: integral.sl
+Encoding: 1114819 -1 4326
+Width: 731
+Flags: W
+ItalicCorrection: 300
+IsExtendedShape: 1
+GlyphVariantsVertical: integral.sl integral.slsize1
+LayerCount: 2
+Back
+SplineSet
+190 -45 m 0
+ 190 35 188 61 188 141 c 2
+ 188 452 l 2
+ 188 698 246 810 352 810 c 0
+ 381 810 405 792 405 767 c 0
+ 405 745 385 728 361 728 c 0
+ 329 728 327 761 303 761 c 0
+ 282 761 262 724 262 591 c 0
+ 262 541 266 469 266 406 c 2
+ 266 107 l 2
+ 266 -198 202 -289 104 -289 c 0
+ 72 -289 50 -271 50 -246 c 0
+ 50 -226 70 -209 89 -209 c 0
+ 116 -209 130 -240 147 -240 c 0
+ 175 -240 190 -122 190 -45 c 0
+EndSplineSet
+Fore
+SplineSet
+238 -45 m 0
+ 256 35 261 61 279 141 c 2
+ 350 452 l 2
+ 407 698 491 810 597 810 c 0
+ 626 810 646 792 640 767 c 0
+ 635 745 611 728 587 728 c 0
+ 555 728 561 761 537 761 c 0
+ 516 761 487 724 456 591 c 0
+ 444 541 433 469 418 406 c 2
+ 349 107 l 2
+ 279 -198 193 -289 95 -289 c 0
+ 63 -289 45 -271 51 -246 c 0
+ 56 -226 80 -209 99 -209 c 0
+ 126 -209 133 -240 150 -240 c 0
+ 178 -240 220 -122 238 -45 c 0
+EndSplineSet
+EndChar
+
+StartChar: uni222C.sl
+Encoding: 1114820 -1 4327
+Width: 971
+Flags: W
+ItalicCorrection: 300
+IsExtendedShape: 1
+GlyphVariantsVertical: uni222C.sl uni222C.slsize1
+LayerCount: 2
+Fore
+Refer: 4326 -1 N 1 0 0 1 240 0 2
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni222D.sl
+Encoding: 1114821 -1 4328
+Width: 1211
+Flags: W
+ItalicCorrection: 300
+IsExtendedShape: 1
+GlyphVariantsVertical: uni222D.sl uni222D.slsize1
+LayerCount: 2
+Fore
+Refer: 4326 -1 N 1 0 0 1 480 0 2
+Refer: 4326 -1 N 1 0 0 1 240 0 2
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni222E.sl
+Encoding: 1114822 -1 4329
+Width: 731
+Flags: W
+ItalicCorrection: 100
+IsExtendedShape: 1
+GlyphVariantsVertical: uni222E.sl uni222E.slsize1
+LayerCount: 2
+Fore
+SplineSet
+185 260 m 0
+ 185 172 257 100 345 100 c 0
+ 433 100 505 172 505 260 c 0
+ 505 348 433 420 345 420 c 0
+ 257 420 185 348 185 260 c 0
+145 260 m 0
+ 145 370 235 460 345 460 c 0
+ 455 460 545 370 545 260 c 0
+ 545 150 455 60 345 60 c 0
+ 235 60 145 150 145 260 c 0
+EndSplineSet
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni222F.sl
+Encoding: 1114823 -1 4330
+Width: 971
+Flags: W
+ItalicCorrection: 100
+IsExtendedShape: 1
+GlyphVariantsVertical: uni222F.sl uni222F.slsize1
+LayerCount: 2
+Fore
+SplineSet
+585 60 m 2
+ 345 60 l 2
+ 235 60 145 150 145 260 c 0
+ 145 370 235 460 345 460 c 2
+ 585 460 l 2
+ 695 460 785 370 785 260 c 0
+ 785 150 695 60 585 60 c 2
+585 420 m 2
+ 345 420 l 2
+ 257 420 185 348 185 260 c 0
+ 185 172 257 100 345 100 c 2
+ 585 100 l 2
+ 673 100 745 172 745 260 c 0
+ 745 348 673 420 585 420 c 2
+EndSplineSet
+Refer: 4327 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2230.sl
+Encoding: 1114824 -1 4331
+Width: 1211
+Flags: W
+ItalicCorrection: 100
+IsExtendedShape: 1
+GlyphVariantsVertical: uni2230.sl uni2230.slsize1
+LayerCount: 2
+Fore
+SplineSet
+825 60 m 2
+ 345 60 l 2
+ 235 60 145 150 145 260 c 0
+ 145 370 235 460 345 460 c 2
+ 825 460 l 2
+ 935 460 1025 370 1025 260 c 0
+ 1025 150 935 60 825 60 c 2
+825 420 m 2
+ 345 420 l 2
+ 257 420 185 348 185 260 c 0
+ 185 172 257 100 345 100 c 2
+ 825 100 l 2
+ 913 100 985 172 985 260 c 0
+ 985 348 913 420 825 420 c 2
+EndSplineSet
+Refer: 4328 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2231.sl
+Encoding: 1114825 -1 4332
+Width: 731
+Flags: W
+ItalicCorrection: 100
+IsExtendedShape: 1
+GlyphVariantsVertical: uni2231.sl uni2231.slsize1
+LayerCount: 2
+Fore
+SplineSet
+505 260 m 0
+ 505 348 433 420 345 420 c 0
+ 257 420 185 348 185 260 c 1
+ 179 254 151 254 145 260 c 1
+ 145 370 235 460 345 460 c 0
+ 455 460 545 370 545 260 c 0
+ 505 260 l 0
+EndSplineSet
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+Refer: 1231 8963 N -0.5 0 0 -0.5 685 496 2
+EndChar
+
+StartChar: uni2232.sl
+Encoding: 1114826 -1 4333
+Width: 731
+Flags: W
+ItalicCorrection: 100
+IsExtendedShape: 1
+GlyphVariantsVertical: uni2232.sl uni2232.slsize1
+LayerCount: 2
+Fore
+SplineSet
+185 260 m 0
+ 185 172 257 100 345 100 c 0
+ 433 100 505 172 505 260 c 0
+ 505 348 433 420 345 420 c 0
+ 257 420 185 348 185 260 c 0
+145 260 m 0
+ 145 370 235 460 345 460 c 0
+ 455 460 545 370 545 260 c 0
+ 545 150 455 60 345 60 c 0
+ 235 60 145 150 145 260 c 0
+EndSplineSet
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+Refer: 1231 8963 N -0.5 0 0 -0.5 685 496 2
+EndChar
+
+StartChar: uni2233.sl
+Encoding: 1114827 -1 4334
+Width: 731
+Flags: W
+ItalicCorrection: 100
+IsExtendedShape: 1
+GlyphVariantsVertical: uni2233.sl uni2233.slsize1
+LayerCount: 2
+Fore
+SplineSet
+185 260 m 0
+ 185 172 257 100 345 100 c 0
+ 433 100 505 172 505 260 c 0
+ 505 348 433 420 345 420 c 0
+ 257 420 185 348 185 260 c 0
+145 260 m 0
+ 145 370 235 460 345 460 c 0
+ 455 460 545 370 545 260 c 0
+ 545 150 455 60 345 60 c 0
+ 235 60 145 150 145 260 c 0
+EndSplineSet
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+Refer: 1231 8963 N 0.5 0 0 0.5 361 24 2
+EndChar
+
+StartChar: integral.slsize1
+Encoding: 1114828 -1 4335
+Width: 1176
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Back
+SplineSet
+266 -169 m 0
+ 269 30 269 153 269 256 c 2
+ 269 694 l 2
+ 269 803 271 1052 288 1306 c 0
+ 296 1440 322 1524 339 1554 c 0
+ 374 1617 438 1654 529 1654 c 0
+ 568 1654 594 1634 594 1599 c 0
+ 594 1569 574 1546 540 1546 c 0
+ 497 1546 489 1585 443 1585 c 0
+ 419 1585 402 1553 398 1516 c 0
+ 391 1455 385 1386 384 1293 c 0
+ 381 1094 381 971 381 868 c 2
+ 381 430 l 2
+ 381 321 379 72 362 -182 c 0
+ 354 -316 328 -400 311 -430 c 0
+ 276 -493 212 -530 121 -530 c 0
+ 82 -530 56 -510 56 -475 c 0
+ 56 -445 76 -422 110 -422 c 0
+ 153 -422 161 -461 207 -461 c 0
+ 231 -461 248 -429 252 -392 c 0
+ 259 -331 265 -262 266 -169 c 0
+EndSplineSet
+Fore
+SplineSet
+339 -169 m 0
+ 388 30 416 153 440 256 c 2
+ 541 694 l 2
+ 566 803 626 1052 702 1306 c 0
+ 741 1440 786 1524 810 1554 c 0
+ 860 1617 932 1654 1023 1654 c 0
+ 1062 1654 1083 1634 1075 1599 c 0
+ 1068 1569 1043 1546 1009 1546 c 0
+ 966 1546 967 1585 921 1585 c 0
+ 897 1585 873 1553 860 1516 c 0
+ 839 1455 817 1386 795 1293 c 0
+ 746 1094 717 971 693 868 c 2
+ 592 430 l 2
+ 567 321 508 72 432 -182 c 0
+ 393 -316 348 -400 324 -430 c 0
+ 274 -493 202 -530 111 -530 c 0
+ 72 -530 50 -510 58 -475 c 0
+ 65 -445 91 -422 125 -422 c 0
+ 168 -422 167 -461 213 -461 c 0
+ 237 -461 261 -429 274 -392 c 0
+ 295 -331 317 -262 339 -169 c 0
+EndSplineSet
+EndChar
+
+StartChar: uni222C.slsize1
+Encoding: 1114829 -1 4336
+Width: 1516
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4335 -1 N 1 0 0 1 340 0 2
+Refer: 4335 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni222D.slsize1
+Encoding: 1114830 -1 4337
+Width: 1856
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4335 -1 N 1 0 0 1 680 0 2
+Refer: 4335 -1 N 1 0 0 1 340 0 2
+Refer: 4335 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni222E.slsize1
+Encoding: 1114831 -1 4338
+Width: 1176
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+309 562 m 0
+ 309 421 423 307 564 307 c 0
+ 705 307 819 421 819 562 c 0
+ 819 703 705 817 564 817 c 0
+ 423 817 309 703 309 562 c 0
+248 562 m 0
+ 248 736 390 878 564 878 c 0
+ 738 878 880 736 880 562 c 0
+ 880 388 738 246 564 246 c 0
+ 390 246 248 388 248 562 c 0
+EndSplineSet
+Refer: 4335 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni222F.slsize1
+Encoding: 1114832 -1 4339
+Width: 1516
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+564 817 m 0
+ 423 817 309 703 309 562 c 0
+ 309 421 423 307 564 307 c 0
+ 904 307 l 0
+ 1045 307 1159 421 1159 562 c 0
+ 1159 703 1045 817 904 817 c 0
+ 564 817 l 0
+564 246 m 0
+ 390 246 248 388 248 562 c 0
+ 248 736 390 878 564 878 c 0
+ 904 878 l 0
+ 1078 878 1220 736 1220 562 c 0
+ 1220 388 1078 246 904 246 c 0
+ 564 246 l 0
+EndSplineSet
+Refer: 4336 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2230.slsize1
+Encoding: 1114833 -1 4340
+Width: 1856
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+564 817 m 0
+ 423 817 309 703 309 562 c 0
+ 309 421 423 307 564 307 c 0
+ 1244 307 l 0
+ 1385 307 1499 421 1499 562 c 0
+ 1499 703 1385 817 1244 817 c 0
+ 564 817 l 0
+564 246 m 0
+ 390 246 248 388 248 562 c 0
+ 248 736 390 878 564 878 c 0
+ 1244 878 l 0
+ 1418 878 1560 736 1560 562 c 0
+ 1560 388 1418 246 1244 246 c 0
+ 564 246 l 0
+EndSplineSet
+Refer: 4337 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2231.slsize1
+Encoding: 1114834 -1 4341
+Width: 1176
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+248 562 m 0
+ 248 736 390 878 564 878 c 0
+ 738 878 880 736 880 562 c 0
+ 849 534 l 0
+ 819 562 l 0
+ 819 703 705 817 564 817 c 0
+ 423 817 309 703 309 562 c 0
+ 248 562 l 0
+866.72 575.8 m 1
+ 886.16 599.56 919.28 629.08 979.76 657.16 c 1
+ 979.76 628.36 l 1
+ 979.04 628.36 886.88 550.6 855.2 472.84 c 1
+ 838.64 472.84 l 1
+ 826.4 508.12 786.08 566.44 716.24 628.36 c 1
+ 716.24 655.72 l 1
+ 768.08 634.12 806.96 598.84 829.28 575.8 c 1
+ 849.44 554.92 l 1
+ 866.72 575.8 l 1
+EndSplineSet
+Refer: 4335 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2232.slsize1
+Encoding: 1114835 -1 4342
+Width: 1176
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+309 562 m 0
+ 309 421 423 307 564 307 c 0
+ 705 307 819 421 819 562 c 0
+ 819 703 705 817 564 817 c 0
+ 423 817 309 703 309 562 c 0
+248 562 m 0
+ 248 736 390 878 564 878 c 0
+ 738 878 880 736 880 562 c 0
+ 880 388 738 246 564 246 c 0
+ 390 246 248 388 248 562 c 0
+866.72 575.8 m 1
+ 886.16 599.56 919.28 629.08 979.76 657.16 c 1
+ 979.76 628.36 l 1
+ 979.04 628.36 886.88 550.6 855.2 472.84 c 1
+ 838.64 472.84 l 1
+ 826.4 508.12 786.08 566.44 716.24 628.36 c 1
+ 716.24 655.72 l 1
+ 768.08 634.12 806.96 598.84 829.28 575.8 c 1
+ 849.44 554.92 l 1
+ 866.72 575.8 l 1
+EndSplineSet
+Refer: 4335 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2233.slsize1
+Encoding: 1114836 -1 4343
+Width: 1176
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+SplineSet
+309 562 m 0
+ 309 421 423 307 564 307 c 0
+ 705 307 819 421 819 562 c 0
+ 819 703 705 817 564 817 c 0
+ 423 817 309 703 309 562 c 0
+248 562 m 0
+ 248 736 390 878 564 878 c 0
+ 738 878 880 736 880 562 c 0
+ 880 388 738 246 564 246 c 0
+ 390 246 248 388 248 562 c 0
+866.72 554.2 m 1
+ 849.44 575.08 l 1
+ 829.28 554.2 l 1
+ 806.96 531.16 768.08 495.88 716.24 474.28 c 1
+ 716.24 501.64 l 1
+ 786.08 563.56 826.4 621.88 838.64 657.16 c 1
+ 855.2 657.16 l 1
+ 886.88 579.4 979.04 501.64 979.76 501.64 c 1
+ 979.76 472.84 l 1
+ 919.28 500.92 886.16 530.44 866.72 554.2 c 1
+EndSplineSet
+Refer: 4335 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2A0C.sl
+Encoding: 1114837 -1 4344
+Width: 1451
+Flags: W
+ItalicCorrection: 300
+IsExtendedShape: 1
+GlyphVariantsVertical: uni2A0C.sl uni2A0C.slsize1
+LayerCount: 2
+Fore
+Refer: 4326 -1 N 1 0 0 1 720 0 2
+Refer: 4326 -1 N 1 0 0 1 480 0 2
+Refer: 4326 -1 N 1 0 0 1 240 0 2
+Refer: 4326 -1 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni2A0C.slsize1
+Encoding: 1114838 -1 4345
+Width: 2196
+Flags: W
+ItalicCorrection: 650
+IsExtendedShape: 1
+LayerCount: 2
+Fore
+Refer: 4335 -1 N 1 0 0 1 1020 0 2
+Refer: 4335 -1 N 1 0 0 1 680 0 2
+Refer: 4335 -1 N 1 0 0 1 340 0 2
+Refer: 4335 -1 N 1 0 0 1 0 0 2
 EndChar
 EndChars
 EndSplineFont

--- a/sources/features/gsub.fea
+++ b/sources/features/gsub.fea
@@ -62,4 +62,6 @@ languagesystem math dflt;
 
 #ifdef MATH
 #include "ssty.fea"
+
+#include "integrals.fea"
 #endif

--- a/sources/features/integrals.fea
+++ b/sources/features/integrals.fea
@@ -1,0 +1,24 @@
+#ifdef MATH
+feature ss08 {
+  sub integral by integral.sl;
+  sub uni222C by uni222C.sl;
+  sub uni222D by uni222D.sl;
+  sub uni222E by uni222E.sl;
+  sub uni222F by uni222F.sl;
+  sub uni2230 by uni2230.sl;
+  sub uni2231 by uni2231.sl;
+  sub uni2232 by uni2232.sl;
+  sub uni2233 by uni2233.sl;
+  sub uni2A0C by uni2A0C.sl;
+  sub integral.size1 by integral.slsize1;
+  sub uni222C.size1 by uni222C.slsize1;
+  sub uni222D.size1 by uni222D.slsize1;
+  sub uni222E.size1 by uni222E.slsize1;
+  sub uni222F.size1 by uni222F.slsize1;
+  sub uni2230.size1 by uni2230.slsize1;
+  sub uni2231.size1 by uni2231.slsize1;
+  sub uni2232.size1 by uni2232.slsize1;
+  sub uni2233.size1 by uni2233.slsize1;
+  sub uni2A0C.size1 by uni2A0C.slsize1;
+} ss08;
+#endif


### PR DESCRIPTION
Closes #357. The slanted versions were added using the `Italic...` function in FontForge, because it transformed the terminals more nicely than anything I tried by hand. Below are the shapes.

[integrals_shapes.pdf](https://github.com/alerque/libertinus/files/5761586/integrals_shapes.pdf)

An important note would be about italic correction and the placement of the limits, which I discussed in #357.

Like STIX, I created a stylistic set `ss08` to cover the slanted variant. I think it would be best to leave the upright version as default; I rather like it and it sits well with the font. I also added the display variants to the respective vertical-variants table. I learned some things that might be of interest for future reference.

When typesetting a display variant `$$\int$$`, TeX starts with an ordinary small-integral glyph. The stylistic alternative is applied first, and *then* the lookup for the display variant in the MATH table happens. When building the font, any `ss08` table entries regarding the `.size1` glyphs are ignored, because those glyphs are probably not recognized as used at the time (it's the bottom half of `integrals.fea`). Fortunately, this does not affect anything, as the vertical variants in the MATH table take care of the substitution. So far so good, just explaining this for the record.

As a suggestion for future revisions, the regular-sized path integrals have really small arrows. Because those glyphs are used in body text and are quite small, the direction of the arrow becomes illegible. Latin Modern solves this by disconnecting the ring. The reader then assumes that the speck on one of the ring ends is the arrow, and the direction of the integration is much clearer.
![image](https://user-images.githubusercontent.com/7095181/103479288-02783980-4dcd-11eb-972e-7c363fe7c1b9.png)


This PR builds on top of the added angle brackets, so I'll rebase it if needed after PR #417 is addressed.