### PR TITLE
fix(serif): Rebuild composite U+1E22 with correct base

### DIFF
--- a/sources/LibertinusSerifDisplay-Regular.sfd
+++ b/sources/LibertinusSerifDisplay-Regular.sfd
@@ -6847,8 +6847,8 @@ GlyphClass: 2
 Flags: MW
 LayerCount: 2
 Fore
-Refer: 627 775 N 1 0 0 1 542 183 2
-Refer: 1959 72 N 1 0 0 1 0 0 3
+Refer: 627 775 N 1 0 0 1 542 193 2
+Refer: 1957 72 N 1 0 0 1 0 0 3
 Colour: ff00ff
 EndChar
 


### PR DESCRIPTION
Fixes #421. This was broken in d7a4859 when I rebuild dot-above glyphs as composites rather than copies of the full shape outline. I have no idea how this happened as I was just using FontForge's build->composite function and that function is also what fixed this.