### PR TITLE
Add base marks and accents for combining diacritics

### DIFF
--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -47,6 +47,7 @@ Lookup: 258 0 0 "'kern' Cyrillic kerning" { "'kern' Cyrillic Kerning" [150,0,6] 
 Lookup: 258 0 0 "'kern' Greek kerning" { "'kern' Greek Kerning" [150,0,6] } ['kern' ('DFLT' <'dflt' > 'grek' <'dflt' > ) ]
 Lookup: 257 0 0 "'cpsp' Versalabstaende" { "'cpsp' Versalabstaende 1"  } ['cpsp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 Lookup: 260 0 0 "'mark' Mark positioning" { "'mark' Komb OR"  "'mark' Right"  "'mark' Above"  "'mark' Middle"  "'mark' Ogonek"  "'mark' Cedilla"  "'mark' Below"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 262 0 0 "'mkmk' Mark-to-Mark positioning" { "'mkmk' Mark-to-Mark 1"  } ['mkmk' ('DFLT' <'dflt' > 'bopo' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > 'musc' <'dflt' > ) ]
 Lookup: 258 0 0 "'kern' Kerning" { "'kern' Latin kerning" [150,0,4] } ['kern' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 MarkAttachClasses: 1
 DEI: 91125
@@ -305,7 +306,7 @@ Grid
  193 550 l 1
  -463 550 l 1025
 EndSplineSet
-AnchorClass2: "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
+AnchorClass2: "aboveMark" "'mkmk' Mark-to-Mark 1" "right" "'mark' Right" "below" "'mark' Below" "cedilla" "'mark' Cedilla" "ogonek" "'mark' Ogonek" "middle" "'mark' Middle" "above" "'mark' Above" "komb_OR" "'mark' Komb OR"
 BeginChars: 1114403 2396
 
 StartChar: exclam
@@ -14936,6 +14937,7 @@ Encoding: 596 596 632
 Width: 389
 GlyphClass: 2
 Flags: MW
+AnchorPoint: "above" 322 654 basechar 0
 AnchorPoint: "below" 172 -114 basechar 0
 LayerCount: 2
 Fore
@@ -15021,6 +15023,7 @@ Encoding: 603 603 635
 Width: 402
 GlyphClass: 2
 Flags: MW
+AnchorPoint: "above" 321.829 654 basechar 0
 AnchorPoint: "below" 212 -114 basechar 0
 LayerCount: 2
 Fore
@@ -16254,6 +16257,8 @@ Encoding: 768 768 671
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" -38 526 mark 0
+AnchorPoint: "aboveMark" 5 731 basemark 0
 AnchorPoint: "above" -3 683 mark 0
 LayerCount: 2
 Fore
@@ -16275,6 +16280,8 @@ Encoding: 769 769 672
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" -42 731 basemark 0
+AnchorPoint: "aboveMark" -84 518 mark 0
 AnchorPoint: "above" -52.2 682 mark 0
 LayerCount: 2
 Fore
@@ -16296,6 +16303,8 @@ Encoding: 770 770 673
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" 2.8 718 basemark 0
+AnchorPoint: "aboveMark" -35 533 mark 0
 AnchorPoint: "above" 2.8 697 mark 0
 LayerCount: 2
 Fore
@@ -16316,6 +16325,8 @@ Encoding: 771 771 674
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" -28.5 553 mark 0
+AnchorPoint: "aboveMark" 2.5 689 basemark 0
 AnchorPoint: "above" 2.8 697 mark 0
 LayerCount: 2
 Fore
@@ -16404,6 +16415,8 @@ Encoding: 780 780 678
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" -98.5 512 mark 0
+AnchorPoint: "aboveMark" -60 697 basemark 0
 AnchorPoint: "above" -67.5 676 mark 0
 LayerCount: 2
 Fore
@@ -39213,6 +39226,8 @@ Encoding: 772 772 1410
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" -98 517 mark 0
+AnchorPoint: "aboveMark" -77.8 603 basemark 0
 AnchorPoint: "above" -77.8 645 mark 0
 LayerCount: 2
 Fore

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -15220,8 +15220,8 @@ Encoding: 768 768 669
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -142 870 basemark 0
-AnchorPoint: "aboveMark" -142 683 mark 0
+AnchorPoint: "aboveMark" -142 731 basemark 0
+AnchorPoint: "aboveMark" -142 526 mark 0
 AnchorPoint: "above" -142 683 mark 0
 LayerCount: 2
 Fore
@@ -15243,8 +15243,8 @@ Encoding: 769 769 670
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -191 682 mark 0
-AnchorPoint: "aboveMark" -191 914 basemark 0
+AnchorPoint: "aboveMark" -191 527 mark 0
+AnchorPoint: "aboveMark" -191 731 basemark 0
 AnchorPoint: "above" -191 682 mark 0
 LayerCount: 2
 Fore
@@ -15266,7 +15266,8 @@ Encoding: 770 770 671
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -138 914 basemark 0
+AnchorPoint: "aboveMark" -140 530 mark 0
+AnchorPoint: "aboveMark" -140 733 basemark 0
 AnchorPoint: "above" -139 697 mark 0
 LayerCount: 2
 Fore
@@ -15287,9 +15288,9 @@ Encoding: 771 771 672
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -138 697 mark 0
-AnchorPoint: "aboveMark" -138 874 basemark 0
-AnchorPoint: "above" -139 697 mark 0
+AnchorPoint: "aboveMark" -149 547 mark 0
+AnchorPoint: "aboveMark" -149 694 basemark 0
+AnchorPoint: "above" -149 697 mark 0
 LayerCount: 2
 Fore
 SplineSet
@@ -15329,7 +15330,8 @@ Encoding: 776 776 674
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -210 824 basemark 0
+AnchorPoint: "aboveMark" -210 505 mark 0
+AnchorPoint: "aboveMark" -210 642 basemark 0
 AnchorPoint: "above" -210 645 mark 0
 LayerCount: 2
 Fore
@@ -15379,6 +15381,8 @@ Encoding: 780 780 676
 Width: 0
 GlyphClass: 4
 Flags: MW
+AnchorPoint: "aboveMark" -204 515 mark 0
+AnchorPoint: "aboveMark" -201 663 basemark 0
 AnchorPoint: "above" -205 676 mark 0
 LayerCount: 2
 Fore
@@ -32895,8 +32899,8 @@ Encoding: 774 774 1418
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -161 841 basemark 0
-AnchorPoint: "aboveMark" -161 691 mark 0
+AnchorPoint: "aboveMark" -161 697 basemark 0
+AnchorPoint: "aboveMark" -161 508 mark 0
 AnchorPoint: "above" -161 681 mark 0
 LayerCount: 2
 Fore
@@ -32916,9 +32920,9 @@ Encoding: 772 772 1419
 Width: 0
 GlyphClass: 4
 Flags: MW
-AnchorPoint: "aboveMark" -209 645 mark 0
-AnchorPoint: "aboveMark" -209 824 basemark 0
-AnchorPoint: "above" -209 645 mark 0
+AnchorPoint: "aboveMark" -209 513 mark 0
+AnchorPoint: "aboveMark" -209 606 basemark 0
+AnchorPoint: "above" -209 644 mark 0
 LayerCount: 2
 Fore
 SplineSet


### PR DESCRIPTION
In Serif-Regular and Serif-Italic, these commits add the marks necessary to stack combining diacritics.

It was also necessary to add `above` base marks for ɔ and ɛ.

Example for combinations:
![grafik](https://user-images.githubusercontent.com/10461729/104450764-e3359500-55a0-11eb-96a1-428de833a8c5.png)

Serif-Italics was missing a mark-to-mark lookup table, so I added one, and created aboveMark accents and base marks for some combining diacritics.

I'm wondering whether there's an automated approach to insert these marks in the other typefaces. Otherwise, I'd be happy to add them manually.
