### PR TITLE
Fix Finnish translation of In the beginning...

### DIFF
--- a/documentation/Sample.fodt
+++ b/documentation/Sample.fodt
@@ -1067,7 +1067,7 @@
       <text:p text:style-name="P12"/>
       <text:p text:style-name="P12">Alussa oli Sana, ja Sana oli Jumalan luona, Sana</text:p>
       <text:p text:style-name="P12">oli Jumala.</text:p>
-      <text:p text:style-name="P12">ja hä oli alussa Jumalan luona.</text:p>
+      <text:p text:style-name="P12">Ja hän oli alussa Jumalan luona.</text:p>
       <text:p text:style-name="P12"/>
       <text:p text:style-name="P12">Hapo mwanzo kulikuwako Neno, naye Neno</text:p>
       <text:p text:style-name="P12">alikuwako kwa Mungo, naye Neno alikuwa</text:p>


### PR DESCRIPTION
In the Finnish translation of *In the beginning was the word*, there is a typo, 

    hä -> hän

The translation is a bit odd overall, but at least the typo should be fixed and the *ja* capitalised.