### PR TITLE
Fix some composite Hebrew glyphs

### DIFF
--- a/sources/LibertinusKeyboard-Regular.sfd
+++ b/sources/LibertinusKeyboard-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusKeyboard-Regular
 FullName: Libertinus Keyboard Regular
 FamilyName: Libertinus Keyboard

--- a/sources/LibertinusMath-Regular.sfd
+++ b/sources/LibertinusMath-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusMath-Regular
 FullName: Libertinus Math Regular
 FamilyName: Libertinus Math

--- a/sources/LibertinusMono-Regular.sfd
+++ b/sources/LibertinusMono-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusMono-Regular
 FullName: Libertinus Mono Regular
 FamilyName: Libertinus Mono

--- a/sources/LibertinusSans-Bold.sfd
+++ b/sources/LibertinusSans-Bold.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSans-Bold
 FullName: Libertinus Sans Bold
 FamilyName: Libertinus Sans

--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSans-Italic
 FullName: Libertinus Sans Italic
 FamilyName: Libertinus Sans

--- a/sources/LibertinusSans-Regular.sfd
+++ b/sources/LibertinusSans-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSans-Regular
 FullName: Libertinus Sans Regular
 FamilyName: Libertinus Sans

--- a/sources/LibertinusSerif-Bold.sfd
+++ b/sources/LibertinusSerif-Bold.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-Bold
 FullName: Libertinus Serif Bold
 FamilyName: Libertinus Serif

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-BoldItalic
 FullName: Libertinus Serif Bold Italic
 FamilyName: Libertinus Serif

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -20,6 +20,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1155510122
+ModificationTime: 1727117497
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -151,8 +152,13 @@ KernClass2: 21 21 "'kern' Latin kerning"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 76 {} 80 {} 0 {} 80 {} 40 {} 0 {} 88 {} 0 {} 0 {} 55 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -20 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -44 {} -24 {} 0 {} -61 {} -44 {} -71 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -70 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} -5 {} -34 {} 37 {} 0 {} 10 {} 10 {} 0 {} -29 {} -29 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 15 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 0 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} 0 {} 0 {} -20 {} -20 {} -20 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} -24 {} -40 {} -10 {} 7 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -100 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} -50 {} -12 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -17 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 12 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Caleb Maclennan" "Philipp H. Poll, Khaled Hosny" "" "https://github.com/alerque/libertinus" "" "This Font Software is licensed under the SIL Open Font License, Version 1.1" "https://scripts.sil.org/OFL"
 Encoding: UnicodeFull
+Compacted: 1
 UnicodeInterp: none
 NameList: AGL For New Fonts
+DisplaySize: -72
+AntiAlias: 1
+FitToEm: 0
+WinInfo: 1950 26 10
 BeginPrivate: 9
 BlueValues 47 [-12 1 429 442 460 474 567 578 645 658 688 698]
 OtherBlues 11 [-238 -227]
@@ -73371,6 +73377,7 @@ EndChar
 StartChar: hedagesh
 Encoding: 64308 64308 2409
 Width: 478
+Flags: H
 AnchorPoint: "ganuv" 140 0 basechar 0
 AnchorPoint: "hbmiddle" 234 0 basechar 0
 AnchorPoint: "hbsmall" 238 0 basechar 0
@@ -73380,11 +73387,13 @@ AnchorPoint: "qubuts" 45 0 basechar 0
 LayerCount: 2
 Fore
 Refer: 1842 1468 N 1 0 0 1 -20 0 2
+Refer: 1855 1492 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: vavdagesh
 Encoding: 64309 64309 2410
 Width: 285
+Flags: H
 AnchorPoint: "hbmiddle" 207 0 basechar 0
 AnchorPoint: "hbsmall" 190 0 basechar 0
 AnchorPoint: "hbwide" 130 0 basechar 0
@@ -73393,11 +73402,13 @@ AnchorPoint: "qubuts" -24 0 basechar 0
 LayerCount: 2
 Fore
 Refer: 1842 1468 N 1 0 0 1 -142 0 2
+Refer: 1856 1493 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: zayindagesh
 Encoding: 64310 64310 2411
 Width: 289
+Flags: H
 AnchorPoint: "hbmiddle" 146 0 basechar 0
 AnchorPoint: "hbsmall" 133 0 basechar 0
 AnchorPoint: "hbwide" 110 0 basechar 0
@@ -73406,11 +73417,13 @@ AnchorPoint: "qubuts" -33 0 basechar 0
 LayerCount: 2
 Fore
 Refer: 1842 1468 N 1 0 0 1 -222 0 2
+Refer: 1857 1494 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: tetdagesh
 Encoding: 64312 64312 2412
 Width: 486
+Flags: H
 AnchorPoint: "hbmiddle" 240 0 basechar 0
 AnchorPoint: "hbsmall" 240 0 basechar 0
 AnchorPoint: "hbwide" 245 0 basechar 0
@@ -73418,13 +73431,14 @@ AnchorPoint: "holem" -11 0 basechar 0
 AnchorPoint: "qubuts" 55 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1856 1493 N 1 0 0 1 0 0 2
 Refer: 1842 1468 N 1 0 0 1 18 0 2
+Refer: 2445 1496 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: yoddagesh
 Encoding: 64313 64313 2413
 Width: 270
+Flags: H
 AnchorPoint: "hbmiddle" 137 -4 basechar 0
 AnchorPoint: "hbsmall" 142 -4 basechar 0
 AnchorPoint: "hbwide" 139 0 basechar 0
@@ -73432,8 +73446,8 @@ AnchorPoint: "holem" -40 0 basechar 0
 AnchorPoint: "qubuts" -38 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1857 1494 N 1 0 0 1 0 0 2
 Refer: 1842 1468 N 1 0 0 1 -167 86 2
+Refer: 2446 1497 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: finalkafdagesh
@@ -73611,14 +73625,17 @@ EndChar
 StartChar: vavholam
 Encoding: 64331 64331 2427
 Width: 285
+Flags: H
 LayerCount: 2
 Fore
-Refer: 1839 1465 N 1 0 0 1 0 0 2
+Refer: 1839 1465 N 1 0 0 1 -60 0 2
+Refer: 1856 1493 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: betrafe
 Encoding: 64332 64332 2428
 Width: 468
+Flags: H
 AnchorPoint: "hbmiddle" 234 0 basechar 0
 AnchorPoint: "hbsmall" 225 0 basechar 0
 AnchorPoint: "hbwide" 238 0 basechar 0
@@ -73626,12 +73643,14 @@ AnchorPoint: "holem" 0 0 basechar 0
 AnchorPoint: "qubuts" 32 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1852 1489 N 1 0 0 1 0 0 2
+Refer: 1845 1471 S 1 0 0 1 112 0 2
+Refer: 1852 1489 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: kafrafe
 Encoding: 64333 64333 2429
 Width: 463
+Flags: H
 AnchorPoint: "hbmiddle" 203 0 basechar 0
 AnchorPoint: "hbsmall" 209 0 basechar 0
 AnchorPoint: "hbwide" 209 0 basechar 0
@@ -73639,12 +73658,14 @@ AnchorPoint: "holem" 0 0 basechar 0
 AnchorPoint: "qubuts" 16 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1859 1499 N 1 0 0 1 0 0 2
+Refer: 1845 1471 S 1 0 0 1 112 0 2
+Refer: 1859 1499 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: perafe
 Encoding: 64334 64334 2430
 Width: 474
+Flags: H
 AnchorPoint: "hbmiddle" 234 0 basechar 0
 AnchorPoint: "hbsmall" 227 0 basechar 0
 AnchorPoint: "hbwide" 203 0 basechar 0
@@ -73652,12 +73673,14 @@ AnchorPoint: "holem" 0 0 basechar 0
 AnchorPoint: "qubuts" 5 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1868 1508 N 1 0 0 1 0 0 2
+Refer: 1845 1471 S 1 0 0 1 136 0 2
+Refer: 1868 1508 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: shindageshshindot
 Encoding: 64300 64300 2431
 Width: 612
+Flags: H
 AnchorPoint: "hbmiddle" 266 0 basechar 0
 AnchorPoint: "hbsmall" 266 0 basechar 0
 AnchorPoint: "hbwide" 281 0 basechar 0
@@ -73665,13 +73688,14 @@ AnchorPoint: "holem" -15 0 basechar 0
 AnchorPoint: "qubuts" 70 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 2421 64324 N 1 0 0 1 0 0 2
 Refer: 1847 1473 N 1 0 0 1 96 0 2
+Refer: 2425 64329 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: shindageshsindot
 Encoding: 64301 64301 2432
 Width: 612
+Flags: H
 AnchorPoint: "hbmiddle" 266 0 basechar 0
 AnchorPoint: "hbsmall" 266 0 basechar 0
 AnchorPoint: "hbwide" 281 0 basechar 0
@@ -73679,16 +73703,17 @@ AnchorPoint: "holem" -86 0 basechar 0
 AnchorPoint: "qubuts" 70 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 2421 64324 N 1 0 0 1 0 0 2
 Refer: 1848 1474 N 1 0 0 1 44 0 2
+Refer: 2425 64329 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uniE801
 Encoding: 59393 59393 2433
 Width: 285
-Flags: W
+Flags: HW
 LayerCount: 2
 Fore
+Refer: 1856 1493 S 1 0 0 1 0 0 2
 Refer: 1839 1465 N 1 0 0 1 -82 0 2
 EndChar
 

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-Italic
 FullName: Libertinus Serif Italic
 FamilyName: Libertinus Serif
@@ -20,7 +20,6 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1155510122
-ModificationTime: 1727117497
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -152,13 +151,8 @@ KernClass2: 21 21 "'kern' Latin kerning"
  0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 98 {} 98 {} 98 {} 24 {} 0 {} 0 {} 73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 76 {} 80 {} 0 {} 80 {} 40 {} 0 {} 88 {} 0 {} 0 {} 55 {} 24 {} 24 {} -5 {} -49 {} -34 {} 0 {} -49 {} -63 {} -63 {} -49 {} -20 {} 0 {} 0 {} -59 {} 10 {} 0 {} 37 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -37 {} -44 {} -24 {} 0 {} -61 {} -44 {} -71 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -39 {} 0 {} 24 {} 24 {} 24 {} -34 {} -49 {} -24 {} 0 {} -112 {} -88 {} -70 {} -60 {} -40 {} 0 {} 0 {} -49 {} 0 {} 0 {} 24 {} 0 {} -24 {} 0 {} 0 {} 24 {} 24 {} -24 {} -54 {} 0 {} 0 {} 0 {} 0 {} -20 {} -15 {} 0 {} 0 {} 0 {} -24 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} -5 {} -34 {} 37 {} 0 {} 10 {} 10 {} 0 {} -29 {} -29 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -39 {} -12 {} -24 {} 10 {} 15 {} 10 {} 0 {} -49 {} -59 {} -8 {} 0 {} 0 {} -17 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -12 {} -24 {} 0 {} 0 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -29 {} -37 {} -44 {} 0 {} 0 {} 0 {} -20 {} -20 {} -20 {} 10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -54 {} -54 {} 0 {} -7 {} -7 {} -24 {} -40 {} -10 {} 7 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -63 {} -73 {} -112 {} -34 {} -100 {} 0 {} -73 {} 0 {} 0 {} -12 {} -12 {} -50 {} -12 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -34 {} 0 {} -61 {} -73 {} -73 {} -10 {} 0 {} 0 {} -122 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -73 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -49 {} 0 {} 0 {} 0 {} 0 {} -37 {} 0 {} 0 {} 0 {} 0 {} -10 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -10 {} -17 {} 0 {} 0 {} -24 {} 0 {} -17 {} -12 {} 0 {} 0 {} 73 {} -37 {} 0 {} 12 {} 12 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 37 {} 24 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 24 {} 0 {} 0 {} 0 {} 24 {} -59 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 10 {} 12 {} 49 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} -49 {} -49 {} -24 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {} 0 {}
 LangName: 1033 "" "" "" "" "" "" "" "" "Caleb Maclennan" "Philipp H. Poll, Khaled Hosny" "" "https://github.com/alerque/libertinus" "" "This Font Software is licensed under the SIL Open Font License, Version 1.1" "https://scripts.sil.org/OFL"
 Encoding: UnicodeFull
-Compacted: 1
 UnicodeInterp: none
 NameList: AGL For New Fonts
-DisplaySize: -72
-AntiAlias: 1
-FitToEm: 0
-WinInfo: 1950 26 10
 BeginPrivate: 9
 BlueValues 47 [-12 1 429 442 460 474 567 578 645 658 688 698]
 OtherBlues 11 [-238 -227]
@@ -73377,7 +73371,6 @@ EndChar
 StartChar: hedagesh
 Encoding: 64308 64308 2409
 Width: 478
-Flags: H
 AnchorPoint: "ganuv" 140 0 basechar 0
 AnchorPoint: "hbmiddle" 234 0 basechar 0
 AnchorPoint: "hbsmall" 238 0 basechar 0
@@ -73393,7 +73386,6 @@ EndChar
 StartChar: vavdagesh
 Encoding: 64309 64309 2410
 Width: 285
-Flags: H
 AnchorPoint: "hbmiddle" 207 0 basechar 0
 AnchorPoint: "hbsmall" 190 0 basechar 0
 AnchorPoint: "hbwide" 130 0 basechar 0
@@ -73408,7 +73400,6 @@ EndChar
 StartChar: zayindagesh
 Encoding: 64310 64310 2411
 Width: 289
-Flags: H
 AnchorPoint: "hbmiddle" 146 0 basechar 0
 AnchorPoint: "hbsmall" 133 0 basechar 0
 AnchorPoint: "hbwide" 110 0 basechar 0
@@ -73423,7 +73414,6 @@ EndChar
 StartChar: tetdagesh
 Encoding: 64312 64312 2412
 Width: 486
-Flags: H
 AnchorPoint: "hbmiddle" 240 0 basechar 0
 AnchorPoint: "hbsmall" 240 0 basechar 0
 AnchorPoint: "hbwide" 245 0 basechar 0
@@ -73438,7 +73428,6 @@ EndChar
 StartChar: yoddagesh
 Encoding: 64313 64313 2413
 Width: 270
-Flags: H
 AnchorPoint: "hbmiddle" 137 -4 basechar 0
 AnchorPoint: "hbsmall" 142 -4 basechar 0
 AnchorPoint: "hbwide" 139 0 basechar 0
@@ -73625,7 +73614,6 @@ EndChar
 StartChar: vavholam
 Encoding: 64331 64331 2427
 Width: 285
-Flags: H
 LayerCount: 2
 Fore
 Refer: 1839 1465 N 1 0 0 1 -60 0 2
@@ -73635,7 +73623,6 @@ EndChar
 StartChar: betrafe
 Encoding: 64332 64332 2428
 Width: 468
-Flags: H
 AnchorPoint: "hbmiddle" 234 0 basechar 0
 AnchorPoint: "hbsmall" 225 0 basechar 0
 AnchorPoint: "hbwide" 238 0 basechar 0
@@ -73643,14 +73630,13 @@ AnchorPoint: "holem" 0 0 basechar 0
 AnchorPoint: "qubuts" 32 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1845 1471 S 1 0 0 1 112 0 2
+Refer: 1845 1471 N 1 0 0 1 112 0 2
 Refer: 1852 1489 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: kafrafe
 Encoding: 64333 64333 2429
 Width: 463
-Flags: H
 AnchorPoint: "hbmiddle" 203 0 basechar 0
 AnchorPoint: "hbsmall" 209 0 basechar 0
 AnchorPoint: "hbwide" 209 0 basechar 0
@@ -73658,14 +73644,13 @@ AnchorPoint: "holem" 0 0 basechar 0
 AnchorPoint: "qubuts" 16 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1845 1471 S 1 0 0 1 112 0 2
+Refer: 1845 1471 N 1 0 0 1 112 0 2
 Refer: 1859 1499 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: perafe
 Encoding: 64334 64334 2430
 Width: 474
-Flags: H
 AnchorPoint: "hbmiddle" 234 0 basechar 0
 AnchorPoint: "hbsmall" 227 0 basechar 0
 AnchorPoint: "hbwide" 203 0 basechar 0
@@ -73673,14 +73658,13 @@ AnchorPoint: "holem" 0 0 basechar 0
 AnchorPoint: "qubuts" 5 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1845 1471 S 1 0 0 1 136 0 2
+Refer: 1845 1471 N 1 0 0 1 136 0 2
 Refer: 1868 1508 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: shindageshshindot
 Encoding: 64300 64300 2431
 Width: 612
-Flags: H
 AnchorPoint: "hbmiddle" 266 0 basechar 0
 AnchorPoint: "hbsmall" 266 0 basechar 0
 AnchorPoint: "hbwide" 281 0 basechar 0
@@ -73695,7 +73679,6 @@ EndChar
 StartChar: shindageshsindot
 Encoding: 64301 64301 2432
 Width: 612
-Flags: H
 AnchorPoint: "hbmiddle" 266 0 basechar 0
 AnchorPoint: "hbsmall" 266 0 basechar 0
 AnchorPoint: "hbwide" 281 0 basechar 0
@@ -73710,10 +73693,10 @@ EndChar
 StartChar: uniE801
 Encoding: 59393 59393 2433
 Width: 285
-Flags: HW
+Flags: W
 LayerCount: 2
 Fore
-Refer: 1856 1493 S 1 0 0 1 0 0 2
+Refer: 1856 1493 N 1 0 0 1 0 0 2
 Refer: 1839 1465 N 1 0 0 1 -82 0 2
 EndChar
 

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-Regular
 FullName: Libertinus Serif Regular
 FamilyName: Libertinus Serif

--- a/sources/LibertinusSerif-Semibold.sfd
+++ b/sources/LibertinusSerif-Semibold.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-Semibold
 FullName: Libertinus Serif Semibold
 FamilyName: Libertinus Serif Semibold

--- a/sources/LibertinusSerif-SemiboldItalic.sfd
+++ b/sources/LibertinusSerif-SemiboldItalic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-SemiboldItalic
 FullName: Libertinus Serif Semibold Italic
 FamilyName: Libertinus Serif Semibold

--- a/sources/LibertinusSerifDisplay-Regular.sfd
+++ b/sources/LibertinusSerifDisplay-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerifDisplay-Regular
 FullName: Libertinus Serif Display Regular
 FamilyName: Libertinus Serif Display

--- a/sources/LibertinusSerifInitials-Regular.sfd
+++ b/sources/LibertinusSerifInitials-Regular.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerifInitials-Regular
 FullName: Libertinus Serif Initials Regular
 FamilyName: Libertinus Serif Initials


### PR DESCRIPTION
In Serif Italic there were errors with some composite Hebrew fonts. Bold Italic is fine. This request fixes the issue.